### PR TITLE
Fix #6: Add a KeyProvider SPI to abstract key storage

### DIFF
--- a/src/main/java/io/kroxylicious/filter/pqc/PqcRecordEncryptionFilterFactory.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/PqcRecordEncryptionFilterFactory.java
@@ -53,12 +53,13 @@ public class PqcRecordEncryptionFilterFactory
 
     /**
      * Shared context created once during initialization and passed to each filter instance.
-     * Contains the crypto engine (thread-safe) and compiled topic patterns.
+     * Contains the crypto engine (thread-safe), compiled topic patterns, and key manager.
      */
     public record SharedPqcContext(
             PqcCryptoEngine cryptoEngine,
             List<Pattern> topicPatterns,
-            PqcEncryptionConfig config) {
+            PqcEncryptionConfig config,
+            PqcKeyManager keyManager) {
     }
 
     @Override
@@ -79,14 +80,19 @@ public class PqcRecordEncryptionFilterFactory
                     .map(Pattern::compile)
                     .toList();
 
-            LOG.info("PQC Record Encryption filter initialized successfully with {} key pair",
-                    config.getKemAlgorithm().getDisplayName());
+            LOG.info("PQC Record Encryption filter initialized successfully with {} key pair (provider={})",
+                    config.getKemAlgorithm().getDisplayName(),
+                    config.getKeyProviderType());
 
-            return new SharedPqcContext(cryptoEngine, compiledPatterns, config);
+            return new SharedPqcContext(cryptoEngine, compiledPatterns, config, keyManager);
         }
         catch (GeneralSecurityException | IOException e) {
             throw new PluginConfigurationException(
                     "Failed to initialize PQC encryption: " + e.getMessage(), e);
+        }
+        catch (Exception e) {
+            throw new PluginConfigurationException(
+                    "Failed to initialize key provider: " + e.getMessage(), e);
         }
     }
 
@@ -101,5 +107,8 @@ public class PqcRecordEncryptionFilterFactory
     @Override
     public void close(SharedPqcContext sharedContext) {
         LOG.info("Closing PQC Record Encryption filter");
+        if (sharedContext != null && sharedContext.keyManager() != null) {
+            sharedContext.keyManager().close();
+        }
     }
 }

--- a/src/main/java/io/kroxylicious/filter/pqc/config/PqcEncryptionConfig.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/config/PqcEncryptionConfig.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Configuration for the PQC Record Encryption filter.
@@ -78,19 +77,22 @@ public class PqcEncryptionConfig {
     private final String publicKeyPath;
     private final String privateKeyPath;
     private final List<String> topicPatterns;
+    private final String keyProviderType;
 
     @JsonCreator
     public PqcEncryptionConfig(
             @JsonProperty(value = "kemAlgorithm") KemAlgorithm kemAlgorithm,
             @JsonProperty(value = "hybridMode") Boolean hybridMode,
-            @JsonProperty(value = "publicKeyPath", required = true) String publicKeyPath,
-            @JsonProperty(value = "privateKeyPath", required = true) String privateKeyPath,
-            @JsonProperty(value = "topicPatterns") List<String> topicPatterns) {
+            @JsonProperty(value = "publicKeyPath") String publicKeyPath,
+            @JsonProperty(value = "privateKeyPath") String privateKeyPath,
+            @JsonProperty(value = "topicPatterns") List<String> topicPatterns,
+            @JsonProperty(value = "keyProviderType") String keyProviderType) {
         this.kemAlgorithm = kemAlgorithm != null ? kemAlgorithm : KemAlgorithm.ML_KEM_768;
         this.hybridMode = hybridMode != null ? hybridMode : true;
-        this.publicKeyPath = Objects.requireNonNull(publicKeyPath, "publicKeyPath is required");
-        this.privateKeyPath = Objects.requireNonNull(privateKeyPath, "privateKeyPath is required");
+        this.publicKeyPath = publicKeyPath;
+        this.privateKeyPath = privateKeyPath;
         this.topicPatterns = topicPatterns != null ? List.copyOf(topicPatterns) : List.of(".*");
+        this.keyProviderType = keyProviderType != null ? keyProviderType : "filesystem";
     }
 
     public KemAlgorithm getKemAlgorithm() {
@@ -111,5 +113,9 @@ public class PqcEncryptionConfig {
 
     public List<String> getTopicPatterns() {
         return topicPatterns;
+    }
+
+    public String getKeyProviderType() {
+        return keyProviderType;
     }
 }

--- a/src/main/java/io/kroxylicious/filter/pqc/crypto/FileSystemKeyProvider.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/crypto/FileSystemKeyProvider.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024 Kroxylicious Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kroxylicious.filter.pqc.crypto;
+
+import io.kroxylicious.filter.pqc.config.PqcEncryptionConfig;
+import io.kroxylicious.filter.pqc.config.PqcEncryptionConfig.KemAlgorithm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.List;
+
+/**
+ * Default {@link KeyProvider} implementation that loads ML-KEM key pairs
+ * from the local filesystem. If key files do not exist at the configured
+ * paths, a new key pair is generated and saved automatically.
+ *
+ * <p>Keys are expected in DER encoding:
+ * <ul>
+ *   <li>Public key: X.509 SubjectPublicKeyInfo format</li>
+ *   <li>Private key: PKCS#8 PrivateKeyInfo format</li>
+ * </ul>
+ *
+ * <p>This provider manages a single key pair identified by the key ID
+ * {@value #DEFAULT_KEY_ID}. Key rotation with multiple key pairs is
+ * not supported by this provider.
+ */
+public class FileSystemKeyProvider implements KeyProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileSystemKeyProvider.class);
+
+    static final String DEFAULT_KEY_ID = "default";
+
+    private PublicKey publicKey;
+    private PrivateKey privateKey;
+
+    @Override
+    public String type() {
+        return "filesystem";
+    }
+
+    @Override
+    public void configure(PqcEncryptionConfig config) throws GeneralSecurityException, IOException {
+        KemAlgorithm algorithm = config.getKemAlgorithm();
+        String publicKeyPathStr = config.getPublicKeyPath();
+        String privateKeyPathStr = config.getPrivateKeyPath();
+
+        if (publicKeyPathStr == null || publicKeyPathStr.isEmpty()) {
+            throw new IllegalArgumentException("publicKeyPath is required for filesystem key provider");
+        }
+        if (privateKeyPathStr == null || privateKeyPathStr.isEmpty()) {
+            throw new IllegalArgumentException("privateKeyPath is required for filesystem key provider");
+        }
+
+        Path pubKeyPath = Path.of(publicKeyPathStr);
+        Path privKeyPath = Path.of(privateKeyPathStr);
+
+        if (Files.exists(pubKeyPath) && Files.exists(privKeyPath)) {
+            LOG.info("Loading existing ML-KEM key pair ({}) from {} and {}",
+                    algorithm.getDisplayName(), pubKeyPath, privKeyPath);
+            this.publicKey = PqcCryptoEngine.loadPublicKey(pubKeyPath);
+            this.privateKey = PqcCryptoEngine.loadPrivateKey(privKeyPath);
+        }
+        else {
+            LOG.info("Generating new ML-KEM key pair ({}) and saving to {} and {}",
+                    algorithm.getDisplayName(), pubKeyPath, privKeyPath);
+            KeyPair keyPair = PqcCryptoEngine.generateKeyPair(algorithm);
+            this.publicKey = keyPair.getPublic();
+            this.privateKey = keyPair.getPrivate();
+
+            PqcCryptoEngine.saveKey(pubKeyPath, publicKey.getEncoded());
+            PqcCryptoEngine.saveKey(privKeyPath, privateKey.getEncoded());
+        }
+    }
+
+    @Override
+    public KeyPair getActiveKeyPair(KemAlgorithm algorithm) throws GeneralSecurityException {
+        ensureConfigured();
+        return new KeyPair(publicKey, privateKey);
+    }
+
+    @Override
+    public KeyPair getKeyPairById(String keyId, KemAlgorithm algorithm) throws GeneralSecurityException {
+        ensureConfigured();
+        if (!DEFAULT_KEY_ID.equals(keyId)) {
+            throw new GeneralSecurityException(
+                    "Unknown key ID '" + keyId + "'. FileSystemKeyProvider only supports key ID '" + DEFAULT_KEY_ID + "'");
+        }
+        return new KeyPair(publicKey, privateKey);
+    }
+
+    @Override
+    public List<String> listKeyIds() {
+        return List.of(DEFAULT_KEY_ID);
+    }
+
+    private void ensureConfigured() {
+        if (publicKey == null || privateKey == null) {
+            throw new IllegalStateException("KeyProvider has not been configured. Call configure() first.");
+        }
+    }
+}

--- a/src/main/java/io/kroxylicious/filter/pqc/crypto/KeyProvider.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/crypto/KeyProvider.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 Kroxylicious Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kroxylicious.filter.pqc.crypto;
+
+import io.kroxylicious.filter.pqc.config.PqcEncryptionConfig;
+import io.kroxylicious.filter.pqc.config.PqcEncryptionConfig.KemAlgorithm;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.util.List;
+
+/**
+ * Service Provider Interface for pluggable key storage backends.
+ *
+ * <p>Implementations provide ML-KEM key material from different storage
+ * systems (filesystem, HashiCorp Vault, AWS KMS, etc.). The default
+ * implementation is {@link FileSystemKeyProvider}.
+ *
+ * <p>Implementations are discovered via {@link java.util.ServiceLoader}
+ * and selected by matching the {@link #type()} identifier against the
+ * {@code keyProviderType} field in the filter configuration.
+ *
+ * @see FileSystemKeyProvider
+ */
+public interface KeyProvider {
+
+    /**
+     * Return the type identifier for this provider.
+     * This value is matched against the {@code keyProviderType} configuration
+     * property to select which provider to use.
+     *
+     * @return a non-null type string (e.g., {@code "filesystem"}, {@code "vault"})
+     */
+    String type();
+
+    /**
+     * Configure this provider with the filter's configuration.
+     * Called once at startup before any key operations.
+     *
+     * @param config the filter configuration
+     * @throws GeneralSecurityException if key material cannot be loaded or generated
+     * @throws IOException if an I/O error occurs accessing key storage
+     */
+    void configure(PqcEncryptionConfig config) throws GeneralSecurityException, IOException;
+
+    /**
+     * Load or fetch the active key pair for encryption.
+     *
+     * @param algorithm the ML-KEM algorithm variant to use
+     * @return the active key pair
+     * @throws GeneralSecurityException if the key pair cannot be loaded
+     */
+    KeyPair getActiveKeyPair(KemAlgorithm algorithm) throws GeneralSecurityException;
+
+    /**
+     * Load or fetch a key pair by ID for decryption.
+     * This supports key rotation: old records encrypted with a previous key
+     * can be decrypted by looking up the key ID from the encrypted envelope.
+     *
+     * @param keyId the key identifier
+     * @param algorithm the ML-KEM algorithm variant
+     * @return the key pair for the given ID
+     * @throws GeneralSecurityException if the key pair cannot be found or loaded
+     */
+    KeyPair getKeyPairById(String keyId, KemAlgorithm algorithm) throws GeneralSecurityException;
+
+    /**
+     * List all available key IDs managed by this provider.
+     *
+     * @return an unmodifiable list of key IDs
+     */
+    List<String> listKeyIds();
+
+    /**
+     * Release any resources held by this provider.
+     * Called when the filter is shut down.
+     */
+    default void close() {
+    }
+}

--- a/src/main/java/io/kroxylicious/filter/pqc/crypto/PqcKeyManager.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/crypto/PqcKeyManager.java
@@ -21,64 +21,40 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
-import java.security.PrivateKey;
-import java.security.PublicKey;
+import java.util.ServiceLoader;
 
 /**
  * Manages ML-KEM key pairs for the PQC encryption filter.
- * Handles loading keys from filesystem paths and generating new key pairs.
+ * Delegates key loading and storage to a {@link KeyProvider} implementation
+ * resolved via {@link ServiceLoader}.
  */
 public class PqcKeyManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(PqcKeyManager.class);
 
     private final KemAlgorithm algorithm;
-    private final PublicKey publicKey;
-    private final PrivateKey privateKey;
+    private final KeyProvider keyProvider;
 
     public PqcKeyManager(PqcEncryptionConfig config) throws GeneralSecurityException, IOException {
         this.algorithm = config.getKemAlgorithm();
+        this.keyProvider = resolveKeyProvider(config.getKeyProviderType());
 
-        Path pubKeyPath = Path.of(config.getPublicKeyPath());
-        Path privKeyPath = Path.of(config.getPrivateKeyPath());
-
-        if (Files.exists(pubKeyPath) && Files.exists(privKeyPath)) {
-            LOG.info("Loading existing ML-KEM key pair ({}) from {} and {}",
-                    algorithm.getDisplayName(), pubKeyPath, privKeyPath);
-            this.publicKey = PqcCryptoEngine.loadPublicKey(pubKeyPath);
-            this.privateKey = PqcCryptoEngine.loadPrivateKey(privKeyPath);
-        }
-        else {
-            LOG.info("Generating new ML-KEM key pair ({}) and saving to {} and {}",
-                    algorithm.getDisplayName(), pubKeyPath, privKeyPath);
-            KeyPair keyPair = PqcCryptoEngine.generateKeyPair(algorithm);
-            this.publicKey = keyPair.getPublic();
-            this.privateKey = keyPair.getPrivate();
-
-            PqcCryptoEngine.saveKey(pubKeyPath, publicKey.getEncoded());
-            PqcCryptoEngine.saveKey(privKeyPath, privateKey.getEncoded());
-        }
+        LOG.info("Using key provider: {} (type={})", keyProvider.getClass().getSimpleName(), keyProvider.type());
+        keyProvider.configure(config);
     }
 
     /**
-     * For testing: construct with pre-generated keys.
+     * For testing: construct with a pre-configured key provider.
      */
-    PqcKeyManager(KemAlgorithm algorithm, PublicKey publicKey, PrivateKey privateKey) {
+    PqcKeyManager(KemAlgorithm algorithm, KeyProvider keyProvider) {
         this.algorithm = algorithm;
-        this.publicKey = publicKey;
-        this.privateKey = privateKey;
+        this.keyProvider = keyProvider;
     }
 
-    public PublicKey getPublicKey() {
-        return publicKey;
-    }
-
-    public PrivateKey getPrivateKey() {
-        return privateKey;
+    public KeyProvider getKeyProvider() {
+        return keyProvider;
     }
 
     public KemAlgorithm getAlgorithm() {
@@ -86,9 +62,37 @@ public class PqcKeyManager {
     }
 
     /**
-     * Create a PqcCryptoEngine configured with this key manager's keys.
+     * Create a PqcCryptoEngine configured with the active key pair from this key manager's provider.
      */
-    public PqcCryptoEngine createEngine(boolean hybridMode) {
-        return new PqcCryptoEngine(algorithm, hybridMode, publicKey, privateKey);
+    public PqcCryptoEngine createEngine(boolean hybridMode) throws GeneralSecurityException {
+        KeyPair keyPair = keyProvider.getActiveKeyPair(algorithm);
+        return new PqcCryptoEngine(algorithm, hybridMode, keyPair.getPublic(), keyPair.getPrivate());
+    }
+
+    /**
+     * Close the underlying key provider, releasing any held resources.
+     */
+    public void close() {
+        keyProvider.close();
+    }
+
+    private static KeyProvider resolveKeyProvider(String type) {
+        ServiceLoader<KeyProvider> loader = ServiceLoader.load(KeyProvider.class);
+        for (KeyProvider provider : loader) {
+            if (provider.type().equals(type)) {
+                LOG.debug("Resolved key provider '{}' via ServiceLoader: {}",
+                        type, provider.getClass().getName());
+                return provider;
+            }
+        }
+        // Fallback: if ServiceLoader didn't find it and type is "filesystem", use the built-in default
+        if ("filesystem".equals(type)) {
+            LOG.debug("Using built-in FileSystemKeyProvider");
+            return new FileSystemKeyProvider();
+        }
+        throw new IllegalArgumentException(
+                "No KeyProvider found for type '" + type + "'. "
+                        + "Ensure a KeyProvider implementation with this type is on the classpath "
+                        + "and registered via META-INF/services/" + KeyProvider.class.getName());
     }
 }

--- a/src/main/resources/META-INF/services/io.kroxylicious.filter.pqc.crypto.KeyProvider
+++ b/src/main/resources/META-INF/services/io.kroxylicious.filter.pqc.crypto.KeyProvider
@@ -1,0 +1,1 @@
+io.kroxylicious.filter.pqc.crypto.FileSystemKeyProvider

--- a/src/test/java/io/kroxylicious/filter/pqc/config/PqcEncryptionConfigTest.java
+++ b/src/test/java/io/kroxylicious/filter/pqc/config/PqcEncryptionConfigTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 class PqcEncryptionConfigTest {
 
@@ -30,12 +29,13 @@ class PqcEncryptionConfigTest {
     void shouldUseDefaultValues() {
         // When
         PqcEncryptionConfig config = new PqcEncryptionConfig(
-                null, null, "/tmp/pub.key", "/tmp/priv.key", null);
+                null, null, "/tmp/pub.key", "/tmp/priv.key", null, null);
 
         // Then
         assertThat(config.getKemAlgorithm()).isEqualTo(KemAlgorithm.ML_KEM_768);
         assertThat(config.isHybridMode()).isTrue();
         assertThat(config.getTopicPatterns()).containsExactly(".*");
+        assertThat(config.getKeyProviderType()).isEqualTo("filesystem");
     }
 
     @Test
@@ -44,7 +44,7 @@ class PqcEncryptionConfigTest {
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_1024, false,
                 "/etc/pqc/pub.key", "/etc/pqc/priv.key",
-                List.of("sensitive-.*", "pii-data"));
+                List.of("sensitive-.*", "pii-data"), "filesystem");
 
         // Then
         assertThat(config.getKemAlgorithm()).isEqualTo(KemAlgorithm.ML_KEM_1024);
@@ -52,22 +52,19 @@ class PqcEncryptionConfigTest {
         assertThat(config.getPublicKeyPath()).isEqualTo("/etc/pqc/pub.key");
         assertThat(config.getPrivateKeyPath()).isEqualTo("/etc/pqc/priv.key");
         assertThat(config.getTopicPatterns()).containsExactly("sensitive-.*", "pii-data");
+        assertThat(config.getKeyProviderType()).isEqualTo("filesystem");
     }
 
     @Test
-    void shouldRejectNullPublicKeyPath() {
-        assertThatNullPointerException()
-                .isThrownBy(() -> new PqcEncryptionConfig(
-                        null, null, null, "/tmp/priv.key", null))
-                .withMessageContaining("publicKeyPath");
-    }
+    void shouldAllowNullKeyPaths() {
+        // Key path validation is now handled by the KeyProvider, not the config.
+        // A non-filesystem provider may not need key paths at all.
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                null, null, null, null, null, "vault");
 
-    @Test
-    void shouldRejectNullPrivateKeyPath() {
-        assertThatNullPointerException()
-                .isThrownBy(() -> new PqcEncryptionConfig(
-                        null, null, "/tmp/pub.key", null, null))
-                .withMessageContaining("privateKeyPath");
+        assertThat(config.getPublicKeyPath()).isNull();
+        assertThat(config.getPrivateKeyPath()).isNull();
+        assertThat(config.getKeyProviderType()).isEqualTo("vault");
     }
 
     @Test
@@ -93,6 +90,26 @@ class PqcEncryptionConfigTest {
         assertThat(config.getPublicKeyPath()).isEqualTo("/keys/pub.der");
         assertThat(config.getPrivateKeyPath()).isEqualTo("/keys/priv.der");
         assertThat(config.getTopicPatterns()).containsExactly("orders-.*");
+        assertThat(config.getKeyProviderType()).isEqualTo("filesystem");
+    }
+
+    @Test
+    void shouldDeserializeKeyProviderTypeFromJson() throws Exception {
+        // Given
+        String json = """
+                {
+                    "publicKeyPath": "/keys/pub.der",
+                    "privateKeyPath": "/keys/priv.der",
+                    "keyProviderType": "vault"
+                }
+                """;
+
+        // When
+        ObjectMapper mapper = new ObjectMapper();
+        PqcEncryptionConfig config = mapper.readValue(json, PqcEncryptionConfig.class);
+
+        // Then
+        assertThat(config.getKeyProviderType()).isEqualTo("vault");
     }
 
     @Test
@@ -100,7 +117,7 @@ class PqcEncryptionConfigTest {
         // Given
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 null, null, "/tmp/pub.key", "/tmp/priv.key",
-                List.of("topic1", "topic2"));
+                List.of("topic1", "topic2"), null);
 
         // Then
         assertThat(config.getTopicPatterns()).isUnmodifiable();

--- a/src/test/java/io/kroxylicious/filter/pqc/crypto/FileSystemKeyProviderTest.java
+++ b/src/test/java/io/kroxylicious/filter/pqc/crypto/FileSystemKeyProviderTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2024 Kroxylicious Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kroxylicious.filter.pqc.crypto;
+
+import io.kroxylicious.filter.pqc.config.PqcEncryptionConfig;
+import io.kroxylicious.filter.pqc.config.PqcEncryptionConfig.KemAlgorithm;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.util.ServiceLoader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FileSystemKeyProviderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void shouldReturnFilesystemType() {
+        FileSystemKeyProvider provider = new FileSystemKeyProvider();
+        assertThat(provider.type()).isEqualTo("filesystem");
+    }
+
+    @Test
+    void shouldGenerateKeysWhenFilesDoNotExist() throws Exception {
+        // Given
+        Path pubKeyPath = tempDir.resolve("pub.der");
+        Path privKeyPath = tempDir.resolve("priv.der");
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false,
+                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+
+        FileSystemKeyProvider provider = new FileSystemKeyProvider();
+
+        // When
+        provider.configure(config);
+
+        // Then
+        assertThat(pubKeyPath).exists();
+        assertThat(privKeyPath).exists();
+        KeyPair keyPair = provider.getActiveKeyPair(KemAlgorithm.ML_KEM_768);
+        assertThat(keyPair.getPublic()).isNotNull();
+        assertThat(keyPair.getPrivate()).isNotNull();
+    }
+
+    @Test
+    void shouldLoadExistingKeys() throws Exception {
+        // Given - generate and save keys first
+        Path pubKeyPath = tempDir.resolve("existing-pub.der");
+        Path privKeyPath = tempDir.resolve("existing-priv.der");
+        KeyPair originalKeyPair = PqcCryptoEngine.generateKeyPair(KemAlgorithm.ML_KEM_768);
+        PqcCryptoEngine.saveKey(pubKeyPath, originalKeyPair.getPublic().getEncoded());
+        PqcCryptoEngine.saveKey(privKeyPath, originalKeyPair.getPrivate().getEncoded());
+
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false,
+                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+
+        FileSystemKeyProvider provider = new FileSystemKeyProvider();
+
+        // When
+        provider.configure(config);
+
+        // Then
+        KeyPair loadedKeyPair = provider.getActiveKeyPair(KemAlgorithm.ML_KEM_768);
+        assertThat(loadedKeyPair.getPublic().getEncoded())
+                .isEqualTo(originalKeyPair.getPublic().getEncoded());
+        assertThat(loadedKeyPair.getPrivate().getEncoded())
+                .isEqualTo(originalKeyPair.getPrivate().getEncoded());
+    }
+
+    @Test
+    void shouldReturnDefaultKeyId() {
+        FileSystemKeyProvider provider = new FileSystemKeyProvider();
+        assertThat(provider.listKeyIds()).containsExactly("default");
+    }
+
+    @Test
+    void shouldReturnKeyPairByDefaultId() throws Exception {
+        // Given
+        Path pubKeyPath = tempDir.resolve("pub.der");
+        Path privKeyPath = tempDir.resolve("priv.der");
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false,
+                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+
+        FileSystemKeyProvider provider = new FileSystemKeyProvider();
+        provider.configure(config);
+
+        // When
+        KeyPair keyPair = provider.getKeyPairById("default", KemAlgorithm.ML_KEM_768);
+
+        // Then
+        assertThat(keyPair.getPublic()).isNotNull();
+        assertThat(keyPair.getPrivate()).isNotNull();
+    }
+
+    @Test
+    void shouldRejectUnknownKeyId() throws Exception {
+        // Given
+        Path pubKeyPath = tempDir.resolve("pub.der");
+        Path privKeyPath = tempDir.resolve("priv.der");
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false,
+                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+
+        FileSystemKeyProvider provider = new FileSystemKeyProvider();
+        provider.configure(config);
+
+        // When/Then
+        assertThatThrownBy(() -> provider.getKeyPairById("unknown-key", KemAlgorithm.ML_KEM_768))
+                .isInstanceOf(GeneralSecurityException.class)
+                .hasMessageContaining("Unknown key ID 'unknown-key'");
+    }
+
+    @Test
+    void shouldThrowWhenNotConfigured() {
+        FileSystemKeyProvider provider = new FileSystemKeyProvider();
+
+        assertThatThrownBy(() -> provider.getActiveKeyPair(KemAlgorithm.ML_KEM_768))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not been configured");
+    }
+
+    @Test
+    void shouldRejectNullPublicKeyPath() {
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false,
+                null, "/tmp/priv.der", null, null);
+
+        FileSystemKeyProvider provider = new FileSystemKeyProvider();
+
+        assertThatThrownBy(() -> provider.configure(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("publicKeyPath");
+    }
+
+    @Test
+    void shouldRejectNullPrivateKeyPath() {
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false,
+                "/tmp/pub.der", null, null, null);
+
+        FileSystemKeyProvider provider = new FileSystemKeyProvider();
+
+        assertThatThrownBy(() -> provider.configure(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("privateKeyPath");
+    }
+
+    @Test
+    void shouldProduceWorkingCryptoEngineKeys() throws Exception {
+        // Given
+        Path pubKeyPath = tempDir.resolve("pub.der");
+        Path privKeyPath = tempDir.resolve("priv.der");
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false,
+                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+
+        FileSystemKeyProvider provider = new FileSystemKeyProvider();
+        provider.configure(config);
+        KeyPair keyPair = provider.getActiveKeyPair(KemAlgorithm.ML_KEM_768);
+
+        PqcCryptoEngine engine = new PqcCryptoEngine(
+                KemAlgorithm.ML_KEM_768, false, keyPair.getPublic(), keyPair.getPrivate());
+
+        // When
+        byte[] plaintext = "KeyProvider roundtrip test".getBytes();
+        byte[] encrypted = engine.encrypt(plaintext);
+        byte[] decrypted = engine.decrypt(encrypted);
+
+        // Then
+        assertThat(decrypted).isEqualTo(plaintext);
+    }
+
+    @Test
+    void shouldBeDiscoverableViaServiceLoader() {
+        ServiceLoader<KeyProvider> loader = ServiceLoader.load(KeyProvider.class);
+        boolean found = false;
+        for (KeyProvider provider : loader) {
+            if ("filesystem".equals(provider.type())) {
+                found = true;
+                assertThat(provider).isInstanceOf(FileSystemKeyProvider.class);
+            }
+        }
+        assertThat(found)
+                .as("FileSystemKeyProvider should be discoverable via ServiceLoader")
+                .isTrue();
+    }
+}

--- a/src/test/java/io/kroxylicious/filter/pqc/crypto/PqcKeyManagerTest.java
+++ b/src/test/java/io/kroxylicious/filter/pqc/crypto/PqcKeyManagerTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.security.KeyPair;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PqcKeyManagerTest {
 
@@ -37,7 +38,7 @@ class PqcKeyManagerTest {
         Path privKeyPath = tempDir.resolve("priv.der");
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                pubKeyPath.toString(), privKeyPath.toString(), null);
+                pubKeyPath.toString(), privKeyPath.toString(), null, null);
 
         // When
         PqcKeyManager keyManager = new PqcKeyManager(config);
@@ -45,8 +46,7 @@ class PqcKeyManagerTest {
         // Then
         assertThat(pubKeyPath).exists();
         assertThat(privKeyPath).exists();
-        assertThat(keyManager.getPublicKey()).isNotNull();
-        assertThat(keyManager.getPrivateKey()).isNotNull();
+        assertThat(keyManager.getKeyProvider()).isInstanceOf(FileSystemKeyProvider.class);
         assertThat(keyManager.getAlgorithm()).isEqualTo(KemAlgorithm.ML_KEM_768);
     }
 
@@ -61,24 +61,29 @@ class PqcKeyManagerTest {
 
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                pubKeyPath.toString(), privKeyPath.toString(), null);
+                pubKeyPath.toString(), privKeyPath.toString(), null, null);
 
         // When
         PqcKeyManager keyManager = new PqcKeyManager(config);
 
         // Then
-        assertThat(keyManager.getPublicKey().getEncoded())
+        KeyPair loadedKeyPair = keyManager.getKeyProvider().getActiveKeyPair(KemAlgorithm.ML_KEM_768);
+        assertThat(loadedKeyPair.getPublic().getEncoded())
                 .isEqualTo(keyPair.getPublic().getEncoded());
-        assertThat(keyManager.getPrivateKey().getEncoded())
+        assertThat(loadedKeyPair.getPrivate().getEncoded())
                 .isEqualTo(keyPair.getPrivate().getEncoded());
     }
 
     @Test
     void shouldCreateEngineFromKeyManager() throws Exception {
         // Given
-        KeyPair keyPair = PqcCryptoEngine.generateKeyPair(KemAlgorithm.ML_KEM_768);
-        PqcKeyManager keyManager = new PqcKeyManager(
-                KemAlgorithm.ML_KEM_768, keyPair.getPublic(), keyPair.getPrivate());
+        Path pubKeyPath = tempDir.resolve("pub.der");
+        Path privKeyPath = tempDir.resolve("priv.der");
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false,
+                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+
+        PqcKeyManager keyManager = new PqcKeyManager(config);
 
         // When
         PqcCryptoEngine engine = keyManager.createEngine(false);
@@ -88,5 +93,48 @@ class PqcKeyManagerTest {
         byte[] encrypted = engine.encrypt(plaintext);
         byte[] decrypted = engine.decrypt(encrypted);
         assertThat(decrypted).isEqualTo(plaintext);
+    }
+
+    @Test
+    void shouldRejectUnknownKeyProviderType() {
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false,
+                "/tmp/pub.der", "/tmp/priv.der", null, "nonexistent");
+
+        assertThatThrownBy(() -> new PqcKeyManager(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No KeyProvider found for type 'nonexistent'");
+    }
+
+    @Test
+    void shouldUseFilesystemProviderByDefault() throws Exception {
+        // Given
+        Path pubKeyPath = tempDir.resolve("pub.der");
+        Path privKeyPath = tempDir.resolve("priv.der");
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false,
+                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+
+        // When
+        PqcKeyManager keyManager = new PqcKeyManager(config);
+
+        // Then
+        assertThat(keyManager.getKeyProvider().type()).isEqualTo("filesystem");
+    }
+
+    @Test
+    void shouldUseExplicitFilesystemProviderType() throws Exception {
+        // Given
+        Path pubKeyPath = tempDir.resolve("pub.der");
+        Path privKeyPath = tempDir.resolve("priv.der");
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false,
+                pubKeyPath.toString(), privKeyPath.toString(), null, "filesystem");
+
+        // When
+        PqcKeyManager keyManager = new PqcKeyManager(config);
+
+        // Then
+        assertThat(keyManager.getKeyProvider()).isInstanceOf(FileSystemKeyProvider.class);
     }
 }


### PR DESCRIPTION
## Summary

- Introduce `KeyProvider` interface as an SPI for pluggable key storage backends (filesystem, Vault, AWS KMS, etc.)
- Extract current filesystem key loading into `FileSystemKeyProvider` as the default implementation
- Add `keyProviderType` config property (defaults to `"filesystem"` for backward compatibility)
- Refactor `PqcKeyManager` to resolve providers via `ServiceLoader` and delegate key operations
- Move key path validation from config to provider (non-filesystem providers won't need paths)

## Test plan

- [x] 11 new tests in `FileSystemKeyProviderTest` covering: type identity, key generation, key loading, key ID operations, error handling, ServiceLoader discovery, and crypto roundtrip
- [x] 6 tests in `PqcKeyManagerTest` covering: key generation, key loading, engine creation, unknown provider rejection, default provider, explicit provider type
- [x] 7 tests in `PqcEncryptionConfigTest` covering: defaults, explicit values, null paths allowed, JSON deserialization, key provider type deserialization
- [x] All 36 tests pass (up from 22)
- [x] `mvn package` produces a working shaded JAR

🤖 Generated with [Claude Code](https://claude.com/claude-code)