### PR TITLE
Fix #7: Add HashiCorp Vault KMS backend for key storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ and quantum attacks.
 - **Semantic security** - identical plaintexts produce different ciphertexts (IND-CCA2)
 - **Key auto-generation** - generates and saves ML-KEM keys on first startup if absent
 - **`x-pqc-encrypted` header** - marks encrypted records for downstream awareness
+- **Pluggable key providers** - `KeyProvider` SPI supports filesystem (default) and HashiCorp Vault backends
 
 ## Prerequisites
 
@@ -61,6 +62,14 @@ mvn clean package -DskipTests
 
 The shaded JAR at `target/kroxylicious-pqc-filter-1.0.0-SNAPSHOT.jar` bundles
 Bouncy Castle so it can be dropped into Kroxylicious with no extra dependencies.
+
+To include HashiCorp Vault key provider support, build with the `vault` profile:
+
+```bash
+mvn clean package -Pvault -DskipTests
+```
+
+This bundles `spring-vault-core` and the `VaultKeyProvider` into the JAR.
 
 ### 2. Generate ML-KEM keys
 
@@ -132,9 +141,54 @@ instead of the broker directly.
 |----------|------|----------|---------|-------------|
 | `kemAlgorithm` | enum | No | `ML_KEM_768` | ML-KEM parameter set. One of `ML_KEM_512`, `ML_KEM_768`, `ML_KEM_1024`. |
 | `hybridMode` | boolean | No | `true` | Combine ML-KEM with X25519 ECDH for defense-in-depth. |
-| `publicKeyPath` | string | **Yes** | - | Filesystem path to the ML-KEM public key (X.509 DER encoded). |
-| `privateKeyPath` | string | **Yes** | - | Filesystem path to the ML-KEM private key (PKCS#8 DER encoded). |
+| `publicKeyPath` | string | Filesystem only | - | Filesystem path to the ML-KEM public key (X.509 DER encoded). |
+| `privateKeyPath` | string | Filesystem only | - | Filesystem path to the ML-KEM private key (PKCS#8 DER encoded). |
 | `topicPatterns` | list\<string\> | No | `[".*"]` | Java regex patterns. Only records in matching topics are encrypted/decrypted. |
+| `keyProviderType` | string | No | `filesystem` | Key storage backend. One of `filesystem`, `vault`. |
+| `keyProviderConfig` | map\<string, string\> | Vault only | `{}` | Backend-specific configuration (see Vault section below). |
+
+### Key Providers
+
+**Filesystem** (`keyProviderType: filesystem`, default):
+Loads ML-KEM keys from DER files on disk. If the files do not exist, generates
+a fresh key pair and saves them. Requires `publicKeyPath` and `privateKeyPath`.
+
+**HashiCorp Vault** (`keyProviderType: vault`, requires `-Pvault` build):
+Fetches ML-KEM keys from a Vault KV v2 secrets engine. Keys are stored as
+base64-encoded DER in `publicKey` and `privateKey` fields. Vault secret versions
+map to key IDs for key rotation support.
+
+Vault `keyProviderConfig` properties:
+
+| Property | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `vaultAddress` | Yes | `VAULT_ADDR` env | Vault server URL (e.g., `http://vault:8200`) |
+| `vaultToken` | For `token` auth | `VAULT_TOKEN` env | Vault authentication token |
+| `secretPath` | Yes | -- | Path within the secrets engine (e.g., `kroxylicious/pqc`) |
+| `secretEngine` | No | `secret` | KV v2 secrets engine mount name |
+| `authMethod` | No | `token` | Auth method: `token`, `approle`, or `kubernetes` |
+| `roleId` | For `approle` | -- | AppRole role ID |
+| `secretId` | For `approle` | -- | AppRole secret ID |
+| `kubeRole` | For `kubernetes` | -- | Kubernetes auth role name |
+| `kubeTokenPath` | No | `/var/run/secrets/.../token` | Service account token file path |
+
+Example Vault configuration:
+
+```yaml
+filterDefinitions:
+  - name: pqc-encryption
+    type: PqcRecordEncryptionFilterFactory
+    config:
+      kemAlgorithm: ML_KEM_768
+      hybridMode: false
+      keyProviderType: vault
+      keyProviderConfig:
+        vaultAddress: http://vault:8200
+        vaultToken: my-token
+        secretPath: kroxylicious/pqc
+      topicPatterns:
+        - "sensitive-.*"
+```
 
 ### ML-KEM Parameter Sets
 
@@ -189,15 +243,25 @@ kroxylicious-pqc-filter/
     config/
       PqcEncryptionConfig.java              # Jackson-deserialized configuration POJO
     crypto/
+      KeyProvider.java                      # SPI interface for pluggable key backends
+      FileSystemKeyProvider.java            # Default: loads/generates keys from disk
       PqcCryptoEngine.java                  # ML-KEM encapsulation + AES-256-GCM
-      PqcKeyManager.java                    # Key loading, generation, persistence
+      PqcKeyManager.java                    # Resolves KeyProvider via ServiceLoader
+  src/main/java-vault/                      # (vault profile only)
+    .../crypto/
+      VaultKeyProvider.java                 # HashiCorp Vault KV v2 key provider
   src/main/resources/
     META-INF/services/
-      io.kroxylicious.proxy.filter.FilterFactory   # ServiceLoader registration
-  src/test/java/...                                # Unit tests (22 tests)
+      io.kroxylicious.proxy.filter.FilterFactory   # ServiceLoader: filter registration
+      io.kroxylicious.filter.pqc.crypto.KeyProvider # ServiceLoader: key provider
+  src/main/resources-vault/                 # (vault profile only)
+    META-INF/services/
+      io.kroxylicious.filter.pqc.crypto.KeyProvider # Registers both FS + Vault providers
+  src/test/java/...                                # Unit tests (49 tests)
+  src/test/java-vault/...                          # Vault provider tests (17 tests)
   examples/
     standalone/                             # Runs without Kafka (crypto engine demo)
-    docker/                                 # Docker Compose: Kafka + Kroxylicious + filter
+    docker/                                 # Docker Compose: Kafka + Vault + Kroxylicious
 ```
 
 ### Filter Lifecycle
@@ -257,12 +321,16 @@ Stateless except for key material and `SecureRandom`.
 `encrypt()` returns a self-describing envelope; `decrypt()` parses it.
 Registers Bouncy Castle providers (`BC`, `BCPQC`) in a static initializer.
 
-**`PqcKeyManager`** loads DER-encoded keys from disk.
-If key files do not exist, generates a fresh ML-KEM key pair and saves them.
+**`PqcKeyManager`** resolves a `KeyProvider` via `ServiceLoader`, matching by
+`keyProviderType`. Delegates all key operations to the resolved provider.
+
+**`KeyProvider`** is the SPI interface for pluggable key storage backends.
+Implementations are discovered via `META-INF/services`. Built-in providers:
+`FileSystemKeyProvider` (default) and `VaultKeyProvider` (with `-Pvault`).
 
 **`PqcEncryptionConfig`** is a Jackson-annotated POJO.
 Deserialized from the `config:` block in the Kroxylicious proxy YAML.
-All fields except `publicKeyPath` and `privateKeyPath` have defaults.
+Supports `keyProviderType` and `keyProviderConfig` for backend selection.
 
 ## Building and Testing
 
@@ -270,11 +338,14 @@ All fields except `publicKeyPath` and `privateKeyPath` have defaults.
 # Compile
 mvn compile
 
-# Run unit tests (22 tests)
+# Run unit tests (38 core tests)
 mvn test
 
 # Package (creates shaded JAR with Bouncy Castle bundled)
 mvn package
+
+# Build with Vault support (55 tests: 38 core + 17 vault)
+mvn package -Pvault
 
 # Install to local Maven repository
 mvn install
@@ -285,8 +356,12 @@ mvn install
 | Test Class | Tests | What is verified |
 |------------|------:|------------------|
 | `PqcCryptoEngineTest` | 12 | Encrypt/decrypt roundtrip for all 3 ML-KEM variants, null handling, empty and 1MB payloads, semantic security, tamper detection, invalid version rejection, key generation, envelope version bytes |
-| `PqcEncryptionConfigTest` | 7 | Default values, explicit values, null rejection, JSON deserialization, immutability, enum properties |
-| `PqcKeyManagerTest` | 3 | Key auto-generation, loading existing keys, engine creation from key manager |
+| `PqcEncryptionConfigTest` | 9 | Default values, explicit values, null rejection, JSON deserialization, immutability, enum properties, keyProviderConfig deserialization |
+| `PqcKeyManagerTest` | 6 | KeyProvider resolution, engine creation, delegation to providers, fallback for filesystem type |
+| `FileSystemKeyProviderTest` | 11 | Key generation, loading existing keys, default key ID, unknown key ID rejection, null path validation, ServiceLoader discovery, crypto roundtrip |
+| `VaultKeyProviderTest` | 17 | Config validation (missing path/address/token/approle/kube), key fetch from Vault, versioned key retrieval, cached keys, invalid versions, missing fields in secret, crypto roundtrip, close behavior |
+
+Total: **55 tests** (38 core + 17 vault)
 
 ## Dependencies
 
@@ -300,6 +375,7 @@ mvn install
 | `org.bouncycastle:bcprov-jdk18on` | 1.83 | compile | ML-KEM, AES-GCM, X25519 (bundled in shaded JAR) |
 | `org.bouncycastle:bcutil-jdk18on` | 1.83 | compile | Bouncy Castle utilities (bundled in shaded JAR) |
 | `org.slf4j:slf4j-api` | 2.0.17 | provided | Logging |
+| `org.springframework.vault:spring-vault-core` | 3.1.2 | compile (vault profile) | Vault KV v2 client (bundled when built with `-Pvault`) |
 
 ### Test
 
@@ -321,11 +397,13 @@ to network and disk I/O.
 
 ## Security Considerations
 
-- **Key protection**: The private key file must be readable only by the
-  Kroxylicious process. Use filesystem permissions (`chmod 600`) and
-  consider mounting from a secrets manager or HSM.
-- **Key rotation**: Generate a new key pair periodically. The version byte
-  in the envelope allows future support for key ID headers.
+- **Key protection (filesystem)**: The private key file must be readable only
+  by the Kroxylicious process. Use filesystem permissions (`chmod 600`).
+- **Key protection (Vault)**: Use Vault policies to restrict access to the
+  secret path. Prefer `approle` or `kubernetes` auth over static tokens
+  in production. Never commit Vault tokens to version control.
+- **Key rotation**: The Vault key provider supports key versioning via Vault
+  secret versions. New versions encrypt; old versions can still decrypt.
 - **Tombstones**: Records with `null` values (Kafka tombstones) are passed
   through unencrypted.
 - **Headers**: Record headers are **not** encrypted, only values.

--- a/examples/README.md
+++ b/examples/README.md
@@ -115,30 +115,39 @@ DEMO 6: Performance Benchmark
 
 ---
 
-## Example 2: Docker Compose (Kafka + Kroxylicious + PQC Filter)
+## Example 2: Docker Compose (Kafka + Kroxylicious + Vault + PQC Filter)
 
-This example runs a full end-to-end setup with a real Kafka broker and
-the Kroxylicious proxy configured with the PQC encryption filter.
+This example runs a full end-to-end setup with a real Kafka broker,
+HashiCorp Vault for key management, and the Kroxylicious proxy configured
+with the PQC encryption filter. ML-KEM key material is stored in Vault
+KV v2 and fetched by the filter at startup.
 
 ### Architecture
 
 ```
-                      ┌───────────────────────────────────────────┐
-                      │              Docker Compose               │
-                      │                                           │
- Producer ──:9192──>  │  Kroxylicious (:9192)  ──:29092──> Kafka  │
- (plaintext)          │    PQC filter encrypts                    │
-                      │                                           │
- Consumer <──:9192──  │  Kroxylicious (:9192)  <──:29092── Kafka  │
- (plaintext)          │    PQC filter decrypts                    │
-                      │                                           │
- Consumer <──:9092──  │                           Kafka (:9092)   │
- (encrypted!)         │                           (direct access) │
-                      └───────────────────────────────────────────┘
+                      ┌──────────────────────────────────────────────────────┐
+                      │                    Docker Compose                    │
+                      │                                                      │
+                      │  Vault (:8200)                                       │
+                      │    KV v2: secret/kroxylicious/pqc                    │
+                      │    (publicKey + privateKey, base64-encoded DER)       │
+                      │        ^                                             │
+                      │        | fetches keys at startup                     │
+                      │        |                                             │
+ Producer ──:9192──>  │  Kroxylicious (:9192)  ──:29092──> Kafka             │
+ (plaintext)          │    PQC filter encrypts                               │
+                      │                                                      │
+ Consumer <──:9192──  │  Kroxylicious (:9192)  <──:29092── Kafka             │
+ (plaintext)          │    PQC filter decrypts                               │
+                      │                                                      │
+ Consumer <──:9092──  │                           Kafka (:9092)              │
+ (encrypted!)         │                           (direct access)            │
+                      └──────────────────────────────────────────────────────┘
 ```
 
 Clients connect to **port 9192** (proxy) and see plaintext.
 Direct access to **port 9092** (broker) shows encrypted binary data.
+Vault UI is accessible at **port 8200** (token: `pqc-demo-token`).
 
 ### Prerequisites
 
@@ -148,11 +157,11 @@ Direct access to **port 9092** (broker) shows encrypted binary data.
 
 ### Step-by-step
 
-#### 1. Build the filter JAR
+#### 1. Build the filter JAR (with Vault support)
 
 ```bash
-# From the project root
-mvn clean package -DskipTests
+# From the project root — the -Pvault profile bundles spring-vault-core
+mvn clean package -Pvault -DskipTests
 ```
 
 #### 2. Generate ML-KEM key pair
@@ -167,6 +176,7 @@ java -cp target/kroxylicious-pqc-filter-1.0.0-SNAPSHOT.jar \
 ```
 
 This creates `pqc-public.der` and `pqc-private.der` in the keys directory.
+These files are used to seed Vault on startup (see step 3).
 
 #### 3. Start the infrastructure
 
@@ -175,14 +185,30 @@ cd examples/docker
 docker compose up -d
 ```
 
-Wait for Kafka to become healthy:
+This starts four services in order:
+1. **Vault** (dev mode) -- ready in ~5 seconds
+2. **vault-init** -- reads the DER key files, base64-encodes them, and stores
+   them in Vault at `secret/kroxylicious/pqc`, then exits
+3. **Kafka** -- KRaft broker (no Zookeeper)
+4. **Kroxylicious** -- starts once Kafka is healthy and Vault keys are seeded
+
+Wait for all services to be ready:
 
 ```bash
-docker compose logs -f kafka
-# Look for: "Kafka Server started"
+docker compose logs -f kroxylicious
+# Look for: "Kroxylicious is started"
 ```
 
-#### 4. Produce messages (encrypted by proxy)
+#### 4. Verify keys in Vault (optional)
+
+```bash
+docker exec pqc-demo-vault vault kv get secret/kroxylicious/pqc
+```
+
+This shows the base64-encoded `publicKey` and `privateKey` fields stored in
+Vault KV v2, along with the secret version number.
+
+#### 5. Produce messages (encrypted by proxy)
 
 ```bash
 cd examples/docker
@@ -193,7 +219,7 @@ mvn compile exec:java \
 
 The producer connects to the proxy at `localhost:9192` and sends 5 sample
 orders containing credit card data. The proxy **encrypts them transparently**
-before storing on the broker.
+using the ML-KEM keys fetched from Vault.
 
 Expected output:
 
@@ -215,7 +241,7 @@ All messages sent successfully!
 Messages are stored PQC-encrypted on the Kafka broker.
 ```
 
-#### 5. Consume through the proxy (decrypted)
+#### 6. Consume through the proxy (decrypted)
 
 ```bash
 mvn compile exec:java \
@@ -241,7 +267,7 @@ Record #2 [partition=0, offset=1]
 ...
 ```
 
-#### 6. Consume directly from broker (encrypted blobs)
+#### 7. Consume directly from broker (encrypted blobs)
 
 ```bash
 mvn compile exec:java \
@@ -268,9 +294,9 @@ Messages appear as encrypted blobs (not readable without the proxy).
 ```
 
 This confirms that data at rest on the Kafka broker is PQC-encrypted and
-unreadable without the ML-KEM private key.
+unreadable without the ML-KEM private key stored in Vault.
 
-#### 7. Clean up
+#### 8. Clean up
 
 ```bash
 docker compose down
@@ -280,8 +306,24 @@ docker compose down
 
 | Service | Image | Port | Purpose |
 |---------|-------|------|---------|
+| `vault` | `hashicorp/vault:1.19` | 8200 | HashiCorp Vault (dev mode) -- stores ML-KEM key material in KV v2 |
+| `vault-init` | `hashicorp/vault:1.19` | -- | Init container: seeds ML-KEM keys into Vault, then exits |
 | `kafka` | `apache/kafka:3.9.0` | 9092 (external), 29092 (internal) | Kafka broker in KRaft mode (no Zookeeper) |
-| `kroxylicious` | `quay.io/kroxylicious/kroxylicious:0.19.0` | 9192 | Proxy with PQC filter |
+| `kroxylicious` | `quay.io/kroxylicious/kroxylicious:0.19.0` | 9192 | Proxy with PQC filter (keys from Vault) |
+
+### How Vault key seeding works
+
+The `vault-init` container runs `config/vault-init.sh`, which:
+
+1. Waits for Vault to be ready
+2. Reads the pre-generated ML-KEM DER key files from `config/pqc-keys/`
+3. Base64-encodes them
+4. Stores them in Vault KV v2 at `secret/kroxylicious/pqc` with fields
+   `publicKey` and `privateKey`
+5. Exits successfully
+
+The Kroxylicious proxy does not start until `vault-init` completes
+(`service_completed_successfully` dependency).
 
 ### Proxy configuration
 
@@ -294,14 +336,23 @@ filterDefinitions:
     config:
       kemAlgorithm: ML_KEM_768
       hybridMode: false
-      publicKeyPath: /opt/kroxylicious/pqc-keys/pqc-public.der
-      privateKeyPath: /opt/kroxylicious/pqc-keys/pqc-private.der
+      keyProviderType: vault
+      keyProviderConfig:
+        vaultAddress: http://vault:8200
+        vaultToken: pqc-demo-token
+        secretPath: kroxylicious/pqc
+        secretEngine: secret
+        authMethod: token
       topicPatterns:
         - "sensitive-.*"
 
 defaultFilters:
   - pqc-encryption
 ```
+
+The filter uses `keyProviderType: vault` to fetch ML-KEM keys from Vault
+instead of reading DER files from disk. The `keyProviderConfig` map
+specifies the Vault connection details.
 
 Only topics matching `sensitive-.*` are encrypted. Other topics pass through
 unchanged.
@@ -310,6 +361,33 @@ The filter JAR is loaded via the `KROXYLICIOUS_CLASSPATH` environment variable
 set in `docker-compose.yaml`. This tells the Kroxylicious start script to add
 `/opt/kroxylicious/plugins/*` to the Java classpath so the `ServiceLoader` can
 discover the `PqcRecordEncryptionFilterFactory`.
+
+### Vault key provider configuration
+
+| Property | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `vaultAddress` | Yes | `VAULT_ADDR` env | Vault server URL |
+| `vaultToken` | No | `VAULT_TOKEN` env | Token for `token` auth method |
+| `secretPath` | Yes | -- | Path within the secrets engine (e.g., `kroxylicious/pqc`) |
+| `secretEngine` | No | `secret` | KV v2 secrets engine mount |
+| `authMethod` | No | `token` | One of: `token`, `approle`, `kubernetes` |
+| `roleId` | For `approle` | -- | AppRole role ID |
+| `secretId` | For `approle` | -- | AppRole secret ID |
+| `kubeRole` | For `kubernetes` | -- | Kubernetes auth role |
+| `kubeTokenPath` | No | `/var/run/secrets/.../token` | Service account token path |
+
+### Vault secret format
+
+The Vault KV v2 secret must contain two fields:
+
+| Field | Format | Description |
+|-------|--------|-------------|
+| `publicKey` | Base64-encoded X.509 DER | ML-KEM public key |
+| `privateKey` | Base64-encoded PKCS#8 DER | ML-KEM private key |
+
+Secret versions map to key IDs. The filter uses the latest version as the
+active encryption key and can decrypt records encrypted with older versions
+by fetching the corresponding Vault secret version.
 
 ---
 
@@ -371,6 +449,34 @@ consumer.
 The filter JAR is not on the Kroxylicious classpath. Verify the Docker
 volume mount in `docker-compose.yaml` points to the built JAR.
 
+**`No KeyProvider found for type 'vault'`**
+The filter JAR was built without Vault support. Rebuild with:
+```bash
+mvn clean package -Pvault -DskipTests
+```
+
+**`vault-init` container fails or restarts**
+The Vault server may not be ready. Check Vault health:
+```bash
+docker compose logs vault
+docker exec pqc-demo-vault vault status
+```
+
+**`Vault secret missing 'publicKey' field`**
+The keys were not seeded into Vault. Re-run the init container:
+```bash
+docker compose run --rm vault-init
+```
+Or seed manually:
+```bash
+docker exec pqc-demo-vault vault kv put secret/kroxylicious/pqc \
+  publicKey="$(base64 -w 0 config/pqc-keys/pqc-public.der)" \
+  privateKey="$(base64 -w 0 config/pqc-keys/pqc-private.der)"
+```
+
 **`Failed to initialize PQC encryption`**
-The key files are missing or unreadable. Regenerate them with
-`PqcKeyGeneratorCli` and verify the paths in `proxy-config.yaml`.
+Check that the Vault address is reachable from the Kroxylicious container
+and that the token is correct. Verify with:
+```bash
+docker exec pqc-demo-proxy curl -s http://vault:8200/v1/sys/health
+```

--- a/examples/docker/config/proxy-config.yaml
+++ b/examples/docker/config/proxy-config.yaml
@@ -1,5 +1,5 @@
 # =============================================================================
-# Kroxylicious Proxy Configuration for PQC Demo
+# Kroxylicious Proxy Configuration for PQC Demo (Vault-backed keys)
 # =============================================================================
 
 management:
@@ -23,8 +23,13 @@ filterDefinitions:
     config:
       kemAlgorithm: ML_KEM_768
       hybridMode: false
-      publicKeyPath: /opt/kroxylicious/pqc-keys/pqc-public.der
-      privateKeyPath: /opt/kroxylicious/pqc-keys/pqc-private.der
+      keyProviderType: vault
+      keyProviderConfig:
+        vaultAddress: http://vault:8200
+        vaultToken: pqc-demo-token
+        secretPath: kroxylicious/pqc
+        secretEngine: secret
+        authMethod: token
       topicPatterns:
         - "sensitive-.*"
 

--- a/examples/docker/config/vault-init.sh
+++ b/examples/docker/config/vault-init.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# =============================================================================
+# Vault Initialization Script for PQC Demo
+# =============================================================================
+# Reads pre-generated ML-KEM key files (DER format), base64-encodes them,
+# and stores them in Vault KV v2 using the HTTP API directly (wget, no vault CLI).
+# =============================================================================
+
+set -e
+
+VAULT_ADDR="${VAULT_ADDR:-http://vault:8200}"
+VAULT_TOKEN="${VAULT_TOKEN:-pqc-demo-token}"
+SECRET_PATH="${SECRET_PATH:-kroxylicious/pqc}"
+PUB_KEY_FILE="${PUB_KEY_FILE:-/keys/pqc-public.der}"
+PRIV_KEY_FILE="${PRIV_KEY_FILE:-/keys/pqc-private.der}"
+
+echo "Waiting for Vault to be ready at ${VAULT_ADDR}..."
+until wget -qO /dev/null "${VAULT_ADDR}/v1/sys/health" 2>/dev/null; do
+  sleep 1
+done
+echo "Vault is ready."
+
+# Base64-encode the DER key files
+PUB_KEY_B64=$(base64 -w 0 "${PUB_KEY_FILE}")
+PRIV_KEY_B64=$(base64 -w 0 "${PRIV_KEY_FILE}")
+
+echo "Storing ML-KEM key pair in Vault at secret/data/${SECRET_PATH}..."
+BODY="{\"data\":{\"publicKey\":\"${PUB_KEY_B64}\",\"privateKey\":\"${PRIV_KEY_B64}\"}}"
+
+wget -qO /dev/null \
+  --header="X-Vault-Token: ${VAULT_TOKEN}" \
+  --header="Content-Type: application/json" \
+  --post-data="${BODY}" \
+  "${VAULT_ADDR}/v1/secret/data/${SECRET_PATH}"
+
+echo "Keys stored. Verifying..."
+wget -qO /dev/null \
+  --header="X-Vault-Token: ${VAULT_TOKEN}" \
+  "${VAULT_ADDR}/v1/secret/data/${SECRET_PATH}"
+
+echo "Keys successfully stored and verified in Vault."

--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -1,14 +1,17 @@
 # =============================================================================
-# Docker Compose: Kafka + Kroxylicious PQC Filter Demo
+# Docker Compose: Kafka + Kroxylicious PQC Filter + HashiCorp Vault Demo
 # =============================================================================
 #
 # Architecture:
 #
+#   Vault (KV v2)                              <-- Stores ML-KEM key material
+#       ^
+#       |
 #   Producer (localhost:9192)
 #       |
 #       v
 #   Kroxylicious Proxy (:9192)          <-- PQC filter encrypts on Produce
-#       |
+#       |                                    (keys fetched from Vault)
 #       v
 #   Kafka Broker (:9092)                 <-- Stores encrypted records
 #       |
@@ -17,6 +20,10 @@
 #       |
 #       v
 #   Consumer (localhost:9192)
+#
+# Prerequisites:
+#   Build the filter JAR with Vault support:
+#     mvn clean package -Pvault -DskipTests
 #
 # Usage:
 #   docker compose up -d
@@ -35,10 +42,47 @@
 #     -Dexec.mainClass=io.kroxylicious.filter.pqc.examples.PqcConsumerExample \
 #     -Dexec.args="localhost:9092"
 #
+#   # Inspect keys in Vault:
+#   docker exec pqc-demo-vault vault kv get secret/kroxylicious/pqc
+#
 #   docker compose down
 # =============================================================================
 
 services:
+  # ── HashiCorp Vault (dev mode) ────────────────────────────────────────
+  vault:
+    image: hashicorp/vault:1.19
+    container_name: pqc-demo-vault
+    hostname: vault
+    ports:
+      - "8200:8200"
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: pqc-demo-token
+      VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
+    cap_add:
+      - IPC_LOCK
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8200/v1/sys/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+  # ── Vault Key Seeder (runs once, then exits) ──────────────────────────
+  vault-init:
+    image: hashicorp/vault:1.19
+    container_name: pqc-demo-vault-init
+    environment:
+      VAULT_ADDR: http://vault:8200
+      VAULT_TOKEN: pqc-demo-token
+    volumes:
+      - ./config/vault-init.sh:/vault-init.sh:ro
+      - ./config/pqc-keys:/keys:ro
+    entrypoint: ["/bin/sh", "/vault-init.sh"]
+    depends_on:
+      vault:
+        condition: service_healthy
+
   # ── Kafka Broker (KRaft mode, no Zookeeper) ──────────────────────────
   kafka:
     image: apache/kafka:3.9.0
@@ -78,9 +122,10 @@ services:
       KROXYLICIOUS_CLASSPATH: /opt/kroxylicious/plugins/*
     volumes:
       - ./config/proxy-config.yaml:/opt/kroxylicious/config/proxy-config.yaml:ro
-      - ./config/pqc-keys:/opt/kroxylicious/pqc-keys:ro
       - ../../target/kroxylicious-pqc-filter-1.0.0-SNAPSHOT.jar:/opt/kroxylicious/plugins/kroxylicious-pqc-filter.jar:ro
     command: ["--config", "/opt/kroxylicious/config/proxy-config.yaml"]
     depends_on:
       kafka:
         condition: service_healthy
+      vault-init:
+        condition: service_completed_successfully

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 
         <!-- Dependency versions -->
         <kroxylicious.version>0.19.0</kroxylicious.version>
+        <spring.vault.version>3.1.2</spring.vault.version>
         <kafka.version>3.9.0</kafka.version>
         <bouncycastle.version>1.83</bouncycastle.version>
         <jackson.version>2.18.3</jackson.version>
@@ -178,4 +179,65 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <!-- Vault key provider profile: adds Spring Vault dependency and vault-specific sources -->
+        <profile>
+            <id>vault</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.springframework.vault</groupId>
+                    <artifactId>spring-vault-core</artifactId>
+                    <version>${spring.vault.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <!-- Override default resources: exclude base KeyProvider service file,
+                     use the vault one which registers both FileSystem and Vault providers -->
+                <resources>
+                    <resource>
+                        <directory>src/main/resources</directory>
+                        <excludes>
+                            <exclude>META-INF/services/io.kroxylicious.filter.pqc.crypto.KeyProvider</exclude>
+                        </excludes>
+                    </resource>
+                    <resource>
+                        <directory>src/main/resources-vault</directory>
+                    </resource>
+                </resources>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>3.6.0</version>
+                        <executions>
+                            <execution>
+                                <id>add-vault-source</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/main/java-vault</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>add-vault-test-source</id>
+                                <phase>generate-test-sources</phase>
+                                <goals>
+                                    <goal>add-test-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/test/java-vault</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/java-vault/io/kroxylicious/filter/pqc/crypto/VaultKeyProvider.java
+++ b/src/main/java-vault/io/kroxylicious/filter/pqc/crypto/VaultKeyProvider.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2024 Kroxylicious Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kroxylicious.filter.pqc.crypto;
+
+import io.kroxylicious.filter.pqc.config.PqcEncryptionConfig;
+import io.kroxylicious.filter.pqc.config.PqcEncryptionConfig.KemAlgorithm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.vault.authentication.AppRoleAuthentication;
+import org.springframework.vault.authentication.AppRoleAuthenticationOptions;
+import org.springframework.vault.authentication.ClientAuthentication;
+import org.springframework.vault.authentication.KubernetesAuthentication;
+import org.springframework.vault.authentication.KubernetesAuthenticationOptions;
+import org.springframework.vault.authentication.TokenAuthentication;
+import org.springframework.vault.client.VaultEndpoint;
+import org.springframework.vault.core.VaultTemplate;
+import org.springframework.vault.core.VaultVersionedKeyValueOperations;
+import org.springframework.vault.core.VaultVersionedKeyValueTemplate;
+import org.springframework.vault.support.Versioned;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Security;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider;
+
+/**
+ * {@link KeyProvider} implementation that fetches ML-KEM key material
+ * from HashiCorp Vault using Spring Vault.
+ *
+ * <p>Keys are stored in Vault's KV v2 secrets engine as base64-encoded
+ * DER values under the keys {@code publicKey} and {@code privateKey}.
+ *
+ * <p>Supported authentication methods:
+ * <ul>
+ *   <li>{@code token} - static Vault token</li>
+ *   <li>{@code approle} - AppRole role ID + secret ID</li>
+ *   <li>{@code kubernetes} - Kubernetes service account JWT</li>
+ * </ul>
+ *
+ * <h2>Configuration properties</h2>
+ * <p>Set via {@code keyProviderConfig} in the filter YAML:
+ * <pre>
+ * keyProviderType: vault
+ * keyProviderConfig:
+ *   vaultAddress: https://vault.example.com:8200
+ *   secretEngine: secret
+ *   secretPath: kroxylicious/pqc
+ *   authMethod: token
+ *   vaultToken: hvs.xxxxx
+ * </pre>
+ *
+ * <table>
+ * <tr><th>Key</th><th>Required</th><th>Default</th><th>Description</th></tr>
+ * <tr><td>vaultAddress</td><td>No</td><td>{@code VAULT_ADDR} env var</td><td>Vault server URL</td></tr>
+ * <tr><td>authMethod</td><td>No</td><td>token</td><td>One of: token, approle, kubernetes</td></tr>
+ * <tr><td>vaultToken</td><td>For token auth</td><td>{@code VAULT_TOKEN} env var</td><td>Static Vault token</td></tr>
+ * <tr><td>roleId</td><td>For approle</td><td>-</td><td>AppRole role ID</td></tr>
+ * <tr><td>secretId</td><td>For approle</td><td>-</td><td>AppRole secret ID</td></tr>
+ * <tr><td>kubeRole</td><td>For kubernetes</td><td>-</td><td>Kubernetes auth role</td></tr>
+ * <tr><td>kubeTokenPath</td><td>No</td><td>/var/run/secrets/kubernetes.io/serviceaccount/token</td><td>SA token path</td></tr>
+ * <tr><td>secretEngine</td><td>No</td><td>secret</td><td>KV v2 engine mount path</td></tr>
+ * <tr><td>secretPath</td><td>Yes</td><td>-</td><td>Secret path within the engine</td></tr>
+ * </table>
+ */
+public class VaultKeyProvider implements KeyProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VaultKeyProvider.class);
+
+    static final String DEFAULT_KUBE_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+
+    private VaultTemplate vaultTemplate;
+    private String secretEngine;
+    private String secretPath;
+    private PublicKey publicKey;
+    private PrivateKey privateKey;
+    private String activeVersion;
+
+    static {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        if (Security.getProvider("BCPQC") == null) {
+            Security.addProvider(new BouncyCastlePQCProvider());
+        }
+    }
+
+    @Override
+    public String type() {
+        return "vault";
+    }
+
+    @Override
+    public void configure(PqcEncryptionConfig config) throws GeneralSecurityException, IOException {
+        Map<String, String> props = config.getKeyProviderConfig();
+
+        String vaultAddress = getOrEnv(props, "vaultAddress", "VAULT_ADDR");
+        if (vaultAddress == null || vaultAddress.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Vault address is required. Set 'vaultAddress' in keyProviderConfig or VAULT_ADDR environment variable.");
+        }
+
+        this.secretEngine = props.getOrDefault("secretEngine", "secret");
+        this.secretPath = props.get("secretPath");
+        if (secretPath == null || secretPath.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "secretPath is required in keyProviderConfig for the vault key provider.");
+        }
+
+        URI vaultUri = URI.create(vaultAddress);
+        VaultEndpoint endpoint = new VaultEndpoint();
+        endpoint.setScheme(vaultUri.getScheme());
+        endpoint.setHost(vaultUri.getHost());
+        if (vaultUri.getPort() != -1) {
+            endpoint.setPort(vaultUri.getPort());
+        }
+
+        String authMethod = props.getOrDefault("authMethod", "token");
+        ClientAuthentication authentication = createAuthentication(authMethod, props, endpoint);
+
+        this.vaultTemplate = new VaultTemplate(endpoint, authentication);
+
+        LOG.info("Vault key provider configured: address={}, engine={}, path={}, auth={}",
+                vaultAddress, secretEngine, secretPath, authMethod);
+
+        fetchKeys();
+    }
+
+    @Override
+    public KeyPair getActiveKeyPair(KemAlgorithm algorithm) throws GeneralSecurityException {
+        ensureConfigured();
+        return new KeyPair(publicKey, privateKey);
+    }
+
+    @Override
+    public KeyPair getKeyPairById(String keyId, KemAlgorithm algorithm) throws GeneralSecurityException {
+        ensureConfigured();
+        if (keyId.equals(activeVersion)) {
+            return new KeyPair(publicKey, privateKey);
+        }
+        // Fetch a specific version from Vault
+        try {
+            return fetchKeysByVersion(Integer.parseInt(keyId));
+        }
+        catch (NumberFormatException e) {
+            throw new GeneralSecurityException("Invalid Vault version key ID: " + keyId);
+        }
+        catch (IOException e) {
+            throw new GeneralSecurityException("Failed to fetch key version " + keyId + " from Vault", e);
+        }
+    }
+
+    @Override
+    public List<String> listKeyIds() {
+        if (activeVersion == null) {
+            return List.of();
+        }
+        return List.of(activeVersion);
+    }
+
+    @Override
+    public void close() {
+        this.publicKey = null;
+        this.privateKey = null;
+        this.vaultTemplate = null;
+    }
+
+    private void fetchKeys() throws GeneralSecurityException, IOException {
+        VaultVersionedKeyValueOperations kvOps =
+                vaultTemplate.opsForVersionedKeyValue(secretEngine);
+
+        Versioned<Map<String, Object>> secret = kvOps.get(secretPath);
+        if (secret == null || secret.getData() == null) {
+            throw new IOException(
+                    "Secret not found at " + secretEngine + "/" + secretPath + " in Vault");
+        }
+
+        Map<String, Object> data = secret.getData();
+        this.activeVersion = secret.getVersion() != null
+                ? String.valueOf(secret.getVersion().getVersion())
+                : "1";
+
+        this.publicKey = decodePublicKey(data);
+        this.privateKey = decodePrivateKey(data);
+
+        LOG.info("Loaded ML-KEM key pair from Vault (version={})", activeVersion);
+    }
+
+    private KeyPair fetchKeysByVersion(int version) throws GeneralSecurityException, IOException {
+        VaultVersionedKeyValueOperations kvOps =
+                vaultTemplate.opsForVersionedKeyValue(secretEngine);
+
+        Versioned<Map<String, Object>> secret =
+                kvOps.get(secretPath, Versioned.Version.from(version));
+        if (secret == null || secret.getData() == null) {
+            throw new IOException(
+                    "Secret version " + version + " not found at " + secretEngine + "/" + secretPath);
+        }
+
+        Map<String, Object> data = secret.getData();
+        return new KeyPair(decodePublicKey(data), decodePrivateKey(data));
+    }
+
+    private ClientAuthentication createAuthentication(
+            String authMethod, Map<String, String> props, VaultEndpoint endpoint) {
+        return switch (authMethod) {
+            case "token" -> {
+                String token = getOrEnv(props, "vaultToken", "VAULT_TOKEN");
+                if (token == null || token.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "Vault token is required for token auth. "
+                                    + "Set 'vaultToken' in keyProviderConfig or VAULT_TOKEN environment variable.");
+                }
+                yield new TokenAuthentication(token);
+            }
+            case "approle" -> {
+                String roleId = props.get("roleId");
+                String secretId = props.get("secretId");
+                if (roleId == null || secretId == null) {
+                    throw new IllegalArgumentException(
+                            "roleId and secretId are required in keyProviderConfig for approle auth.");
+                }
+                AppRoleAuthenticationOptions options = AppRoleAuthenticationOptions.builder()
+                        .roleId(AppRoleAuthenticationOptions.RoleId.provided(roleId))
+                        .secretId(AppRoleAuthenticationOptions.SecretId.provided(secretId))
+                        .build();
+                yield new AppRoleAuthentication(options, new RestTemplate());
+            }
+            case "kubernetes" -> {
+                String role = props.get("kubeRole");
+                if (role == null || role.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "kubeRole is required in keyProviderConfig for kubernetes auth.");
+                }
+                String tokenPath = props.getOrDefault("kubeTokenPath", DEFAULT_KUBE_TOKEN_PATH);
+                String jwt;
+                try {
+                    jwt = Files.readString(Path.of(tokenPath)).trim();
+                }
+                catch (IOException e) {
+                    throw new IllegalArgumentException(
+                            "Cannot read Kubernetes service account token from " + tokenPath, e);
+                }
+                KubernetesAuthenticationOptions options = KubernetesAuthenticationOptions.builder()
+                        .role(role)
+                        .jwtSupplier(() -> jwt)
+                        .build();
+                yield new KubernetesAuthentication(options, new RestTemplate());
+            }
+            default -> throw new IllegalArgumentException(
+                    "Unsupported Vault auth method: " + authMethod
+                            + ". Supported: token, approle, kubernetes");
+        };
+    }
+
+    private static PublicKey decodePublicKey(Map<String, Object> data) throws GeneralSecurityException {
+        Object raw = data.get("publicKey");
+        if (raw == null) {
+            throw new GeneralSecurityException(
+                    "Vault secret missing 'publicKey' field. "
+                            + "Expected base64-encoded DER (X.509) ML-KEM public key.");
+        }
+        byte[] keyBytes = Base64.getDecoder().decode(raw.toString());
+        KeyFactory kf = KeyFactory.getInstance("Kyber", "BCPQC");
+        return kf.generatePublic(new X509EncodedKeySpec(keyBytes));
+    }
+
+    private static PrivateKey decodePrivateKey(Map<String, Object> data) throws GeneralSecurityException {
+        Object raw = data.get("privateKey");
+        if (raw == null) {
+            throw new GeneralSecurityException(
+                    "Vault secret missing 'privateKey' field. "
+                            + "Expected base64-encoded DER (PKCS#8) ML-KEM private key.");
+        }
+        byte[] keyBytes = Base64.getDecoder().decode(raw.toString());
+        KeyFactory kf = KeyFactory.getInstance("Kyber", "BCPQC");
+        return kf.generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
+    }
+
+    private static String getOrEnv(Map<String, String> props, String key, String envVar) {
+        String value = props.get(key);
+        if (value != null && !value.isEmpty()) {
+            return value;
+        }
+        return System.getenv(envVar);
+    }
+
+    private void ensureConfigured() {
+        if (publicKey == null || privateKey == null) {
+            throw new IllegalStateException("VaultKeyProvider has not been configured. Call configure() first.");
+        }
+    }
+}

--- a/src/main/java/io/kroxylicious/filter/pqc/config/PqcEncryptionConfig.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/config/PqcEncryptionConfig.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Configuration for the PQC Record Encryption filter.
@@ -78,6 +79,7 @@ public class PqcEncryptionConfig {
     private final String privateKeyPath;
     private final List<String> topicPatterns;
     private final String keyProviderType;
+    private final Map<String, String> keyProviderConfig;
 
     @JsonCreator
     public PqcEncryptionConfig(
@@ -86,13 +88,15 @@ public class PqcEncryptionConfig {
             @JsonProperty(value = "publicKeyPath") String publicKeyPath,
             @JsonProperty(value = "privateKeyPath") String privateKeyPath,
             @JsonProperty(value = "topicPatterns") List<String> topicPatterns,
-            @JsonProperty(value = "keyProviderType") String keyProviderType) {
+            @JsonProperty(value = "keyProviderType") String keyProviderType,
+            @JsonProperty(value = "keyProviderConfig") Map<String, String> keyProviderConfig) {
         this.kemAlgorithm = kemAlgorithm != null ? kemAlgorithm : KemAlgorithm.ML_KEM_768;
         this.hybridMode = hybridMode != null ? hybridMode : true;
         this.publicKeyPath = publicKeyPath;
         this.privateKeyPath = privateKeyPath;
         this.topicPatterns = topicPatterns != null ? List.copyOf(topicPatterns) : List.of(".*");
         this.keyProviderType = keyProviderType != null ? keyProviderType : "filesystem";
+        this.keyProviderConfig = keyProviderConfig != null ? Map.copyOf(keyProviderConfig) : Map.of();
     }
 
     public KemAlgorithm getKemAlgorithm() {
@@ -117,5 +121,9 @@ public class PqcEncryptionConfig {
 
     public String getKeyProviderType() {
         return keyProviderType;
+    }
+
+    public Map<String, String> getKeyProviderConfig() {
+        return keyProviderConfig;
     }
 }

--- a/src/main/java/io/kroxylicious/filter/pqc/crypto/PqcKeyManager.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/crypto/PqcKeyManager.java
@@ -23,6 +23,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
+import java.util.Iterator;
+import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
 /**
@@ -78,11 +80,20 @@ public class PqcKeyManager {
 
     private static KeyProvider resolveKeyProvider(String type) {
         ServiceLoader<KeyProvider> loader = ServiceLoader.load(KeyProvider.class);
-        for (KeyProvider provider : loader) {
-            if (provider.type().equals(type)) {
-                LOG.debug("Resolved key provider '{}' via ServiceLoader: {}",
-                        type, provider.getClass().getName());
-                return provider;
+        Iterator<KeyProvider> it = loader.iterator();
+        while (it.hasNext()) {
+            try {
+                KeyProvider provider = it.next();
+                if (provider.type().equals(type)) {
+                    LOG.debug("Resolved key provider '{}' via ServiceLoader: {}",
+                            type, provider.getClass().getName());
+                    return provider;
+                }
+            }
+            catch (ServiceConfigurationError e) {
+                // Skip providers whose classes are not on the classpath
+                // (e.g., optional vault provider when built without -Pvault)
+                LOG.debug("Skipping unavailable KeyProvider: {}", e.getMessage());
             }
         }
         // Fallback: if ServiceLoader didn't find it and type is "filesystem", use the built-in default

--- a/src/main/resources-vault/META-INF/services/io.kroxylicious.filter.pqc.crypto.KeyProvider
+++ b/src/main/resources-vault/META-INF/services/io.kroxylicious.filter.pqc.crypto.KeyProvider
@@ -1,0 +1,2 @@
+io.kroxylicious.filter.pqc.crypto.FileSystemKeyProvider
+io.kroxylicious.filter.pqc.crypto.VaultKeyProvider

--- a/src/test/java-vault/io/kroxylicious/filter/pqc/crypto/VaultKeyProviderTest.java
+++ b/src/test/java-vault/io/kroxylicious/filter/pqc/crypto/VaultKeyProviderTest.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2024 Kroxylicious Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kroxylicious.filter.pqc.crypto;
+
+import io.kroxylicious.filter.pqc.config.PqcEncryptionConfig;
+import io.kroxylicious.filter.pqc.config.PqcEncryptionConfig.KemAlgorithm;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.vault.core.VaultTemplate;
+import org.springframework.vault.core.VaultVersionedKeyValueOperations;
+import org.springframework.vault.support.Versioned;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class VaultKeyProviderTest {
+
+    @Mock
+    VaultTemplate vaultTemplate;
+
+    @Mock
+    VaultVersionedKeyValueOperations kvOps;
+
+    private VaultKeyProvider provider;
+    private KeyPair testKeyPair;
+    private String publicKeyB64;
+    private String privateKeyB64;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        provider = new VaultKeyProvider();
+        testKeyPair = PqcCryptoEngine.generateKeyPair(KemAlgorithm.ML_KEM_768);
+        publicKeyB64 = Base64.getEncoder().encodeToString(testKeyPair.getPublic().getEncoded());
+        privateKeyB64 = Base64.getEncoder().encodeToString(testKeyPair.getPrivate().getEncoded());
+    }
+
+    @Test
+    void shouldReturnVaultType() {
+        assertThat(provider.type()).isEqualTo("vault");
+    }
+
+    @Test
+    void shouldRejectMissingSecretPath() {
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false, null, null, null, "vault",
+                Map.of("vaultAddress", "http://localhost:8200", "vaultToken", "test-token"));
+
+        assertThatThrownBy(() -> provider.configure(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("secretPath");
+    }
+
+    @Test
+    void shouldRejectMissingVaultAddress() {
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false, null, null, null, "vault",
+                Map.of("secretPath", "kroxylicious/pqc"));
+
+        assertThatThrownBy(() -> provider.configure(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Vault address");
+    }
+
+    @Test
+    void shouldRejectMissingTokenForTokenAuth() {
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false, null, null, null, "vault",
+                Map.of("vaultAddress", "http://localhost:8200",
+                        "secretPath", "kroxylicious/pqc",
+                        "authMethod", "token"));
+
+        assertThatThrownBy(() -> provider.configure(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Vault token");
+    }
+
+    @Test
+    void shouldRejectMissingAppRoleCredentials() {
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false, null, null, null, "vault",
+                Map.of("vaultAddress", "http://localhost:8200",
+                        "secretPath", "kroxylicious/pqc",
+                        "authMethod", "approle"));
+
+        assertThatThrownBy(() -> provider.configure(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("roleId and secretId");
+    }
+
+    @Test
+    void shouldRejectMissingKubeRole() {
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false, null, null, null, "vault",
+                Map.of("vaultAddress", "http://localhost:8200",
+                        "secretPath", "kroxylicious/pqc",
+                        "authMethod", "kubernetes"));
+
+        assertThatThrownBy(() -> provider.configure(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("kubeRole");
+    }
+
+    @Test
+    void shouldRejectUnsupportedAuthMethod() {
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false, null, null, null, "vault",
+                Map.of("vaultAddress", "http://localhost:8200",
+                        "secretPath", "kroxylicious/pqc",
+                        "authMethod", "ldap"));
+
+        assertThatThrownBy(() -> provider.configure(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported Vault auth method: ldap");
+    }
+
+    @Test
+    void shouldThrowWhenNotConfigured() {
+        assertThatThrownBy(() -> provider.getActiveKeyPair(KemAlgorithm.ML_KEM_768))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not been configured");
+    }
+
+    @Test
+    void shouldReturnEmptyKeyIdsWhenNotConfigured() {
+        assertThat(provider.listKeyIds()).isEmpty();
+    }
+
+    @Test
+    void shouldFetchAndDecodeKeysFromVault() throws Exception {
+        // Inject the mocked VaultTemplate
+        injectVaultTemplate(provider, vaultTemplate);
+
+        Versioned<Map<String, Object>> secret = Versioned.create(
+                Map.of("publicKey", publicKeyB64, "privateKey", privateKeyB64),
+                Versioned.Version.from(3));
+
+        doReturn(kvOps).when(vaultTemplate).opsForVersionedKeyValue("secret");
+        doReturn(secret).when(kvOps).get("kroxylicious/pqc");
+
+        // Set internal state to simulate post-configure
+        setProviderFields("secret", "kroxylicious/pqc");
+
+        // Trigger key fetch via reflection
+        provider.getClass().getDeclaredMethod("fetchKeys").setAccessible(true);
+        var fetchKeysMethod = provider.getClass().getDeclaredMethod("fetchKeys");
+        fetchKeysMethod.setAccessible(true);
+        fetchKeysMethod.invoke(provider);
+
+        // Verify
+        KeyPair keyPair = provider.getActiveKeyPair(KemAlgorithm.ML_KEM_768);
+        assertThat(keyPair.getPublic().getEncoded()).isEqualTo(testKeyPair.getPublic().getEncoded());
+        assertThat(keyPair.getPrivate().getEncoded()).isEqualTo(testKeyPair.getPrivate().getEncoded());
+        assertThat(provider.listKeyIds()).containsExactly("3");
+    }
+
+    @Test
+    void shouldFetchKeysByVersion() throws Exception {
+        injectVaultTemplate(provider, vaultTemplate);
+        setProviderFields("secret", "kroxylicious/pqc");
+
+        // Set up active key
+        Versioned<Map<String, Object>> latestSecret = Versioned.create(
+                Map.of("publicKey", publicKeyB64, "privateKey", privateKeyB64),
+                Versioned.Version.from(2));
+        when(vaultTemplate.opsForVersionedKeyValue("secret")).thenReturn(kvOps);
+        when(kvOps.get("kroxylicious/pqc")).thenReturn(latestSecret);
+
+        var fetchKeysMethod = provider.getClass().getDeclaredMethod("fetchKeys");
+        fetchKeysMethod.setAccessible(true);
+        fetchKeysMethod.invoke(provider);
+
+        // Set up versioned fetch for an older version
+        KeyPair olderKeyPair = PqcCryptoEngine.generateKeyPair(KemAlgorithm.ML_KEM_768);
+        String olderPubB64 = Base64.getEncoder().encodeToString(olderKeyPair.getPublic().getEncoded());
+        String olderPrivB64 = Base64.getEncoder().encodeToString(olderKeyPair.getPrivate().getEncoded());
+
+        Versioned<Map<String, Object>> olderSecret = Versioned.create(
+                Map.of("publicKey", olderPubB64, "privateKey", olderPrivB64),
+                Versioned.Version.from(1));
+        doReturn(olderSecret).when(kvOps).get(eq("kroxylicious/pqc"), eq(Versioned.Version.from(1)));
+
+        // Fetch by version
+        KeyPair result = provider.getKeyPairById("1", KemAlgorithm.ML_KEM_768);
+        assertThat(result.getPublic().getEncoded()).isEqualTo(olderKeyPair.getPublic().getEncoded());
+    }
+
+    @Test
+    void shouldReturnCachedKeyForActiveVersion() throws Exception {
+        injectVaultTemplate(provider, vaultTemplate);
+        setProviderFields("secret", "kroxylicious/pqc");
+
+        Versioned<Map<String, Object>> secret = Versioned.create(
+                Map.of("publicKey", publicKeyB64, "privateKey", privateKeyB64),
+                Versioned.Version.from(5));
+        doReturn(kvOps).when(vaultTemplate).opsForVersionedKeyValue("secret");
+        doReturn(secret).when(kvOps).get("kroxylicious/pqc");
+
+        var fetchKeysMethod = provider.getClass().getDeclaredMethod("fetchKeys");
+        fetchKeysMethod.setAccessible(true);
+        fetchKeysMethod.invoke(provider);
+
+        // Fetching by active version ID should return cached key, no extra Vault call
+        KeyPair result = provider.getKeyPairById("5", KemAlgorithm.ML_KEM_768);
+        assertThat(result.getPublic().getEncoded()).isEqualTo(testKeyPair.getPublic().getEncoded());
+    }
+
+    @Test
+    void shouldRejectInvalidVersionKeyId() throws Exception {
+        injectVaultTemplate(provider, vaultTemplate);
+        setProviderFields("secret", "kroxylicious/pqc");
+
+        Versioned<Map<String, Object>> secret = Versioned.create(
+                Map.of("publicKey", publicKeyB64, "privateKey", privateKeyB64),
+                Versioned.Version.from(1));
+        doReturn(kvOps).when(vaultTemplate).opsForVersionedKeyValue("secret");
+        doReturn(secret).when(kvOps).get("kroxylicious/pqc");
+
+        var fetchKeysMethod = provider.getClass().getDeclaredMethod("fetchKeys");
+        fetchKeysMethod.setAccessible(true);
+        fetchKeysMethod.invoke(provider);
+
+        assertThatThrownBy(() -> provider.getKeyPairById("not-a-number", KemAlgorithm.ML_KEM_768))
+                .isInstanceOf(GeneralSecurityException.class)
+                .hasMessageContaining("Invalid Vault version key ID");
+    }
+
+    @Test
+    void shouldRejectMissingPublicKeyInSecret() throws Exception {
+        injectVaultTemplate(provider, vaultTemplate);
+        setProviderFields("secret", "kroxylicious/pqc");
+
+        Versioned<Map<String, Object>> secret = Versioned.create(
+                Map.of("privateKey", privateKeyB64),
+                Versioned.Version.from(1));
+        doReturn(kvOps).when(vaultTemplate).opsForVersionedKeyValue("secret");
+        doReturn(secret).when(kvOps).get("kroxylicious/pqc");
+
+        var fetchKeysMethod = provider.getClass().getDeclaredMethod("fetchKeys");
+        fetchKeysMethod.setAccessible(true);
+
+        assertThatThrownBy(() -> fetchKeysMethod.invoke(provider))
+                .hasCauseInstanceOf(GeneralSecurityException.class)
+                .hasRootCauseMessage("Vault secret missing 'publicKey' field. "
+                        + "Expected base64-encoded DER (X.509) ML-KEM public key.");
+    }
+
+    @Test
+    void shouldRejectMissingPrivateKeyInSecret() throws Exception {
+        injectVaultTemplate(provider, vaultTemplate);
+        setProviderFields("secret", "kroxylicious/pqc");
+
+        Versioned<Map<String, Object>> secret = Versioned.create(
+                Map.of("publicKey", publicKeyB64),
+                Versioned.Version.from(1));
+        doReturn(kvOps).when(vaultTemplate).opsForVersionedKeyValue("secret");
+        doReturn(secret).when(kvOps).get("kroxylicious/pqc");
+
+        var fetchKeysMethod = provider.getClass().getDeclaredMethod("fetchKeys");
+        fetchKeysMethod.setAccessible(true);
+
+        assertThatThrownBy(() -> fetchKeysMethod.invoke(provider))
+                .hasCauseInstanceOf(GeneralSecurityException.class)
+                .hasRootCauseMessage("Vault secret missing 'privateKey' field. "
+                        + "Expected base64-encoded DER (PKCS#8) ML-KEM private key.");
+    }
+
+    @Test
+    void shouldProduceWorkingCryptoEngineKeys() throws Exception {
+        injectVaultTemplate(provider, vaultTemplate);
+        setProviderFields("secret", "kroxylicious/pqc");
+
+        Versioned<Map<String, Object>> secret = Versioned.create(
+                Map.of("publicKey", publicKeyB64, "privateKey", privateKeyB64),
+                Versioned.Version.from(1));
+        doReturn(kvOps).when(vaultTemplate).opsForVersionedKeyValue("secret");
+        doReturn(secret).when(kvOps).get("kroxylicious/pqc");
+
+        var fetchKeysMethod = provider.getClass().getDeclaredMethod("fetchKeys");
+        fetchKeysMethod.setAccessible(true);
+        fetchKeysMethod.invoke(provider);
+
+        KeyPair keyPair = provider.getActiveKeyPair(KemAlgorithm.ML_KEM_768);
+        PqcCryptoEngine engine = new PqcCryptoEngine(
+                KemAlgorithm.ML_KEM_768, false, keyPair.getPublic(), keyPair.getPrivate());
+
+        byte[] plaintext = "Vault roundtrip test".getBytes();
+        byte[] encrypted = engine.encrypt(plaintext);
+        byte[] decrypted = engine.decrypt(encrypted);
+        assertThat(decrypted).isEqualTo(plaintext);
+    }
+
+    @Test
+    void shouldClearStateOnClose() throws Exception {
+        injectVaultTemplate(provider, vaultTemplate);
+        setProviderFields("secret", "kroxylicious/pqc");
+
+        Versioned<Map<String, Object>> secret = Versioned.create(
+                Map.of("publicKey", publicKeyB64, "privateKey", privateKeyB64),
+                Versioned.Version.from(1));
+        doReturn(kvOps).when(vaultTemplate).opsForVersionedKeyValue("secret");
+        doReturn(secret).when(kvOps).get("kroxylicious/pqc");
+
+        var fetchKeysMethod = provider.getClass().getDeclaredMethod("fetchKeys");
+        fetchKeysMethod.setAccessible(true);
+        fetchKeysMethod.invoke(provider);
+
+        // Verify keys are loaded
+        assertThat(provider.getActiveKeyPair(KemAlgorithm.ML_KEM_768)).isNotNull();
+
+        // Close and verify state is cleared
+        provider.close();
+        assertThatThrownBy(() -> provider.getActiveKeyPair(KemAlgorithm.ML_KEM_768))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    // --- Test helpers ---
+
+    private void injectVaultTemplate(VaultKeyProvider provider, VaultTemplate template) throws Exception {
+        Field field = VaultKeyProvider.class.getDeclaredField("vaultTemplate");
+        field.setAccessible(true);
+        field.set(provider, template);
+    }
+
+    private void setProviderFields(String engine, String path) throws Exception {
+        Field engineField = VaultKeyProvider.class.getDeclaredField("secretEngine");
+        engineField.setAccessible(true);
+        engineField.set(provider, engine);
+
+        Field pathField = VaultKeyProvider.class.getDeclaredField("secretPath");
+        pathField.setAccessible(true);
+        pathField.set(provider, path);
+    }
+}

--- a/src/test/java/io/kroxylicious/filter/pqc/config/PqcEncryptionConfigTest.java
+++ b/src/test/java/io/kroxylicious/filter/pqc/config/PqcEncryptionConfigTest.java
@@ -20,6 +20,7 @@ import io.kroxylicious.filter.pqc.config.PqcEncryptionConfig.KemAlgorithm;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,13 +30,14 @@ class PqcEncryptionConfigTest {
     void shouldUseDefaultValues() {
         // When
         PqcEncryptionConfig config = new PqcEncryptionConfig(
-                null, null, "/tmp/pub.key", "/tmp/priv.key", null, null);
+                null, null, "/tmp/pub.key", "/tmp/priv.key", null, null, null);
 
         // Then
         assertThat(config.getKemAlgorithm()).isEqualTo(KemAlgorithm.ML_KEM_768);
         assertThat(config.isHybridMode()).isTrue();
         assertThat(config.getTopicPatterns()).containsExactly(".*");
         assertThat(config.getKeyProviderType()).isEqualTo("filesystem");
+        assertThat(config.getKeyProviderConfig()).isEmpty();
     }
 
     @Test
@@ -44,7 +46,7 @@ class PqcEncryptionConfigTest {
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_1024, false,
                 "/etc/pqc/pub.key", "/etc/pqc/priv.key",
-                List.of("sensitive-.*", "pii-data"), "filesystem");
+                List.of("sensitive-.*", "pii-data"), "filesystem", null);
 
         // Then
         assertThat(config.getKemAlgorithm()).isEqualTo(KemAlgorithm.ML_KEM_1024);
@@ -60,7 +62,7 @@ class PqcEncryptionConfigTest {
         // Key path validation is now handled by the KeyProvider, not the config.
         // A non-filesystem provider may not need key paths at all.
         PqcEncryptionConfig config = new PqcEncryptionConfig(
-                null, null, null, null, null, "vault");
+                null, null, null, null, null, "vault", null);
 
         assertThat(config.getPublicKeyPath()).isNull();
         assertThat(config.getPrivateKeyPath()).isNull();
@@ -113,11 +115,48 @@ class PqcEncryptionConfigTest {
     }
 
     @Test
+    void shouldDeserializeKeyProviderConfigFromJson() throws Exception {
+        // Given
+        String json = """
+                {
+                    "keyProviderType": "vault",
+                    "keyProviderConfig": {
+                        "vaultAddress": "https://vault.example.com:8200",
+                        "secretPath": "kroxylicious/pqc",
+                        "authMethod": "token",
+                        "vaultToken": "hvs.test"
+                    }
+                }
+                """;
+
+        // When
+        ObjectMapper mapper = new ObjectMapper();
+        PqcEncryptionConfig config = mapper.readValue(json, PqcEncryptionConfig.class);
+
+        // Then
+        assertThat(config.getKeyProviderType()).isEqualTo("vault");
+        assertThat(config.getKeyProviderConfig())
+                .containsEntry("vaultAddress", "https://vault.example.com:8200")
+                .containsEntry("secretPath", "kroxylicious/pqc")
+                .containsEntry("authMethod", "token")
+                .containsEntry("vaultToken", "hvs.test");
+    }
+
+    @Test
+    void shouldMakeKeyProviderConfigImmutable() {
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                null, null, null, null, null, "vault",
+                Map.of("key", "value"));
+
+        assertThat(config.getKeyProviderConfig()).isUnmodifiable();
+    }
+
+    @Test
     void shouldMakeTopicPatternsImmutable() {
         // Given
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 null, null, "/tmp/pub.key", "/tmp/priv.key",
-                List.of("topic1", "topic2"), null);
+                List.of("topic1", "topic2"), null, null);
 
         // Then
         assertThat(config.getTopicPatterns()).isUnmodifiable();

--- a/src/test/java/io/kroxylicious/filter/pqc/crypto/FileSystemKeyProviderTest.java
+++ b/src/test/java/io/kroxylicious/filter/pqc/crypto/FileSystemKeyProviderTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
+import java.util.Iterator;
+import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,7 +48,7 @@ class FileSystemKeyProviderTest {
         Path privKeyPath = tempDir.resolve("priv.der");
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+                pubKeyPath.toString(), privKeyPath.toString(), null, null, null);
 
         FileSystemKeyProvider provider = new FileSystemKeyProvider();
 
@@ -72,7 +74,7 @@ class FileSystemKeyProviderTest {
 
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+                pubKeyPath.toString(), privKeyPath.toString(), null, null, null);
 
         FileSystemKeyProvider provider = new FileSystemKeyProvider();
 
@@ -100,7 +102,7 @@ class FileSystemKeyProviderTest {
         Path privKeyPath = tempDir.resolve("priv.der");
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+                pubKeyPath.toString(), privKeyPath.toString(), null, null, null);
 
         FileSystemKeyProvider provider = new FileSystemKeyProvider();
         provider.configure(config);
@@ -120,7 +122,7 @@ class FileSystemKeyProviderTest {
         Path privKeyPath = tempDir.resolve("priv.der");
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+                pubKeyPath.toString(), privKeyPath.toString(), null, null, null);
 
         FileSystemKeyProvider provider = new FileSystemKeyProvider();
         provider.configure(config);
@@ -144,7 +146,7 @@ class FileSystemKeyProviderTest {
     void shouldRejectNullPublicKeyPath() {
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                null, "/tmp/priv.der", null, null);
+                null, "/tmp/priv.der", null, null, null);
 
         FileSystemKeyProvider provider = new FileSystemKeyProvider();
 
@@ -157,7 +159,7 @@ class FileSystemKeyProviderTest {
     void shouldRejectNullPrivateKeyPath() {
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                "/tmp/pub.der", null, null, null);
+                "/tmp/pub.der", null, null, null, null);
 
         FileSystemKeyProvider provider = new FileSystemKeyProvider();
 
@@ -173,7 +175,7 @@ class FileSystemKeyProviderTest {
         Path privKeyPath = tempDir.resolve("priv.der");
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+                pubKeyPath.toString(), privKeyPath.toString(), null, null, null);
 
         FileSystemKeyProvider provider = new FileSystemKeyProvider();
         provider.configure(config);
@@ -194,11 +196,18 @@ class FileSystemKeyProviderTest {
     @Test
     void shouldBeDiscoverableViaServiceLoader() {
         ServiceLoader<KeyProvider> loader = ServiceLoader.load(KeyProvider.class);
+        Iterator<KeyProvider> it = loader.iterator();
         boolean found = false;
-        for (KeyProvider provider : loader) {
-            if ("filesystem".equals(provider.type())) {
-                found = true;
-                assertThat(provider).isInstanceOf(FileSystemKeyProvider.class);
+        while (it.hasNext()) {
+            try {
+                KeyProvider provider = it.next();
+                if ("filesystem".equals(provider.type())) {
+                    found = true;
+                    assertThat(provider).isInstanceOf(FileSystemKeyProvider.class);
+                }
+            }
+            catch (ServiceConfigurationError e) {
+                // Skip optional providers not on classpath (e.g., VaultKeyProvider)
             }
         }
         assertThat(found)

--- a/src/test/java/io/kroxylicious/filter/pqc/crypto/PqcKeyManagerTest.java
+++ b/src/test/java/io/kroxylicious/filter/pqc/crypto/PqcKeyManagerTest.java
@@ -38,7 +38,7 @@ class PqcKeyManagerTest {
         Path privKeyPath = tempDir.resolve("priv.der");
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+                pubKeyPath.toString(), privKeyPath.toString(), null, null, null);
 
         // When
         PqcKeyManager keyManager = new PqcKeyManager(config);
@@ -61,7 +61,7 @@ class PqcKeyManagerTest {
 
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+                pubKeyPath.toString(), privKeyPath.toString(), null, null, null);
 
         // When
         PqcKeyManager keyManager = new PqcKeyManager(config);
@@ -81,7 +81,7 @@ class PqcKeyManagerTest {
         Path privKeyPath = tempDir.resolve("priv.der");
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+                pubKeyPath.toString(), privKeyPath.toString(), null, null, null);
 
         PqcKeyManager keyManager = new PqcKeyManager(config);
 
@@ -99,7 +99,7 @@ class PqcKeyManagerTest {
     void shouldRejectUnknownKeyProviderType() {
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                "/tmp/pub.der", "/tmp/priv.der", null, "nonexistent");
+                "/tmp/pub.der", "/tmp/priv.der", null, "nonexistent", null);
 
         assertThatThrownBy(() -> new PqcKeyManager(config))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -113,7 +113,7 @@ class PqcKeyManagerTest {
         Path privKeyPath = tempDir.resolve("priv.der");
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                pubKeyPath.toString(), privKeyPath.toString(), null, null);
+                pubKeyPath.toString(), privKeyPath.toString(), null, null, null);
 
         // When
         PqcKeyManager keyManager = new PqcKeyManager(config);
@@ -129,7 +129,7 @@ class PqcKeyManagerTest {
         Path privKeyPath = tempDir.resolve("priv.der");
         PqcEncryptionConfig config = new PqcEncryptionConfig(
                 KemAlgorithm.ML_KEM_768, false,
-                pubKeyPath.toString(), privKeyPath.toString(), null, "filesystem");
+                pubKeyPath.toString(), privKeyPath.toString(), null, "filesystem", null);
 
         // When
         PqcKeyManager keyManager = new PqcKeyManager(config);


### PR DESCRIPTION
## Summary

- Adds `KeyProvider` SPI (#6) with `ServiceLoader` discovery to abstract key storage from the crypto engine
- Implements `VaultKeyProvider` (#7) using `spring-vault-core` to fetch ML-KEM keys from HashiCorp Vault KV v2
- Supports `token`, `approle`, and `kubernetes` Vault auth methods
- Optional dependency via Maven `-Pvault` profile (separate source dirs, resource overrides)
- Updates Docker example with Vault (dev mode), vault-init seeder, and Vault-backed proxy config
- 55 tests total (38 core + 17 Vault)

## Changes

- **`KeyProvider` SPI**: pluggable key backends via `ServiceLoader` (`FileSystemKeyProvider` default, `VaultKeyProvider` optional)
- **`VaultKeyProvider`**: fetches base64-encoded DER keys from Vault KV v2, supports versioned secrets for key rotation
- **`PqcEncryptionConfig`**: added `keyProviderType` and `keyProviderConfig` fields
- **`PqcKeyManager`**: resilient `ServiceLoader` iteration (catches `ServiceConfigurationError` for missing optional providers)
- **Docker example**: Vault + vault-init containers, `wget`-based key seeding (no vault CLI dependency), proxy config with `keyProviderType: vault`
- **Documentation**: README.md and examples/README.md updated with Vault setup, config reference, troubleshooting

## Test plan

- [x] 17 `VaultKeyProviderTest` tests (config validation, key fetch, versioned keys, auth methods, crypto roundtrip)
- [x] 11 `FileSystemKeyProviderTest` tests (generation, loading, ServiceLoader discovery)
- [x] 6 `PqcKeyManager` tests (provider resolution, delegation, fallback)
- [x] 9 `PqcEncryptionConfigTest` tests (defaults, keyProviderConfig deserialization)
- [x] 12 `PqcCryptoEngineTest` tests (encrypt/decrypt, all ML-KEM variants)
- [x] Docker Compose tested end-to-end (Vault → vault-init → Kafka → Kroxylicious)

🤖 Generated with [Claude Code](https://claude.com/claude-code)