### PR TITLE
Fix #12: Persist X25519 key pair for hybrid mode across proxy restarts

### DIFF
--- a/examples/docker/config/vault-init.sh
+++ b/examples/docker/config/vault-init.sh
@@ -13,6 +13,8 @@ VAULT_TOKEN="${VAULT_TOKEN:-pqc-demo-token}"
 SECRET_PATH="${SECRET_PATH:-kroxylicious/pqc}"
 PUB_KEY_FILE="${PUB_KEY_FILE:-/keys/pqc-public.der}"
 PRIV_KEY_FILE="${PRIV_KEY_FILE:-/keys/pqc-private.der}"
+X25519_PUB_KEY_FILE="${X25519_PUB_KEY_FILE:-/keys/x25519-public.der}"
+X25519_PRIV_KEY_FILE="${X25519_PRIV_KEY_FILE:-/keys/x25519-private.der}"
 
 echo "Waiting for Vault to be ready at ${VAULT_ADDR}..."
 until wget -qO /dev/null "${VAULT_ADDR}/v1/sys/health" 2>/dev/null; do
@@ -23,9 +25,11 @@ echo "Vault is ready."
 # Base64-encode the DER key files
 PUB_KEY_B64=$(base64 -w 0 "${PUB_KEY_FILE}")
 PRIV_KEY_B64=$(base64 -w 0 "${PRIV_KEY_FILE}")
+X25519_PUB_B64=$(base64 -w 0 "${X25519_PUB_KEY_FILE}")
+X25519_PRIV_B64=$(base64 -w 0 "${X25519_PRIV_KEY_FILE}")
 
-echo "Storing ML-KEM key pair in Vault at secret/data/${SECRET_PATH}..."
-BODY="{\"data\":{\"publicKey\":\"${PUB_KEY_B64}\",\"privateKey\":\"${PRIV_KEY_B64}\"}}"
+echo "Storing ML-KEM + X25519 key pairs in Vault at secret/data/${SECRET_PATH}..."
+BODY="{\"data\":{\"publicKey\":\"${PUB_KEY_B64}\",\"privateKey\":\"${PRIV_KEY_B64}\",\"x25519PublicKey\":\"${X25519_PUB_B64}\",\"x25519PrivateKey\":\"${X25519_PRIV_B64}\"}}"
 
 wget -qO /dev/null \
   --header="X-Vault-Token: ${VAULT_TOKEN}" \

--- a/src/main/java-vault/io/kroxylicious/filter/pqc/crypto/VaultKeyProvider.java
+++ b/src/main/java-vault/io/kroxylicious/filter/pqc/crypto/VaultKeyProvider.java
@@ -39,6 +39,7 @@ import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Security;
@@ -101,6 +102,7 @@ public class VaultKeyProvider implements KeyProvider {
     private String secretPath;
     private PublicKey publicKey;
     private PrivateKey privateKey;
+    private KeyPair x25519KeyPair;
     private String activeVersion;
 
     static {
@@ -178,6 +180,11 @@ public class VaultKeyProvider implements KeyProvider {
     }
 
     @Override
+    public KeyPair getX25519KeyPair() {
+        return x25519KeyPair;
+    }
+
+    @Override
     public List<String> listKeyIds() {
         if (activeVersion == null) {
             return List.of();
@@ -189,6 +196,7 @@ public class VaultKeyProvider implements KeyProvider {
     public void close() {
         this.publicKey = null;
         this.privateKey = null;
+        this.x25519KeyPair = null;
         this.vaultTemplate = null;
     }
 
@@ -210,7 +218,13 @@ public class VaultKeyProvider implements KeyProvider {
         this.publicKey = decodePublicKey(data);
         this.privateKey = decodePrivateKey(data);
 
-        LOG.info("Loaded ML-KEM key pair from Vault (version={})", activeVersion);
+        this.x25519KeyPair = decodeX25519KeyPair(data);
+        if (x25519KeyPair != null) {
+            LOG.info("Loaded ML-KEM + X25519 key pairs from Vault (version={})", activeVersion);
+        }
+        else {
+            LOG.info("Loaded ML-KEM key pair from Vault (version={}), no X25519 keys found", activeVersion);
+        }
     }
 
     private KeyPair fetchKeysByVersion(int version) throws GeneralSecurityException, IOException {
@@ -302,6 +316,20 @@ public class VaultKeyProvider implements KeyProvider {
         byte[] keyBytes = Base64.getDecoder().decode(raw.toString());
         KeyFactory kf = KeyFactory.getInstance("Kyber", "BCPQC");
         return kf.generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
+    }
+
+    private static KeyPair decodeX25519KeyPair(Map<String, Object> data) throws GeneralSecurityException {
+        Object rawPub = data.get("x25519PublicKey");
+        Object rawPriv = data.get("x25519PrivateKey");
+        if (rawPub == null || rawPriv == null) {
+            return null;
+        }
+        KeyFactory kf = KeyFactory.getInstance("X25519");
+        PublicKey pub = kf.generatePublic(
+                new X509EncodedKeySpec(Base64.getDecoder().decode(rawPub.toString())));
+        PrivateKey priv = kf.generatePrivate(
+                new PKCS8EncodedKeySpec(Base64.getDecoder().decode(rawPriv.toString())));
+        return new KeyPair(pub, priv);
     }
 
     private static String getOrEnv(Map<String, String> props, String key, String envVar) {

--- a/src/main/java/io/kroxylicious/filter/pqc/PqcKeyGeneratorCli.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/PqcKeyGeneratorCli.java
@@ -95,6 +95,23 @@ public class PqcKeyGeneratorCli {
         System.out.println("Private key: " + privKeyPath.toAbsolutePath());
         System.out.println("  Size:      " + keyPair.getPrivate().getEncoded().length + " bytes");
         System.out.println("  Format:    " + keyPair.getPrivate().getFormat());
+
+        // Generate X25519 key pair for hybrid mode
+        System.out.println("\nGenerating X25519 key pair for hybrid mode...");
+        KeyPairGenerator x25519Gen = KeyPairGenerator.getInstance("X25519");
+        KeyPair x25519KeyPair = x25519Gen.generateKeyPair();
+
+        Path x25519PubPath = Path.of(outputDir, "x25519-public.der");
+        Path x25519PrivPath = Path.of(outputDir, "x25519-private.der");
+
+        Files.write(x25519PubPath, x25519KeyPair.getPublic().getEncoded());
+        Files.write(x25519PrivPath, x25519KeyPair.getPrivate().getEncoded());
+
+        System.out.println("X25519 public key:  " + x25519PubPath.toAbsolutePath());
+        System.out.println("  Size:             " + x25519KeyPair.getPublic().getEncoded().length + " bytes");
+        System.out.println("X25519 private key: " + x25519PrivPath.toAbsolutePath());
+        System.out.println("  Size:             " + x25519KeyPair.getPrivate().getEncoded().length + " bytes");
+
         System.out.println("\nDone. Add these paths to your Kroxylicious proxy configuration.");
     }
 }

--- a/src/main/java/io/kroxylicious/filter/pqc/crypto/FileSystemKeyProvider.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/crypto/FileSystemKeyProvider.java
@@ -52,6 +52,7 @@ public class FileSystemKeyProvider implements KeyProvider {
 
     private PublicKey publicKey;
     private PrivateKey privateKey;
+    private KeyPair x25519KeyPair;
 
     @Override
     public String type() {
@@ -90,6 +91,24 @@ public class FileSystemKeyProvider implements KeyProvider {
             PqcCryptoEngine.saveKey(pubKeyPath, publicKey.getEncoded());
             PqcCryptoEngine.saveKey(privKeyPath, privateKey.getEncoded());
         }
+
+        if (config.isHybridMode()) {
+            Path x25519PubPath = pubKeyPath.getParent().resolve("x25519-public.der");
+            Path x25519PrivPath = pubKeyPath.getParent().resolve("x25519-private.der");
+
+            if (Files.exists(x25519PubPath) && Files.exists(x25519PrivPath)) {
+                LOG.info("Loading existing X25519 key pair from {} and {}", x25519PubPath, x25519PrivPath);
+                this.x25519KeyPair = new KeyPair(
+                        PqcCryptoEngine.loadX25519PublicKey(x25519PubPath),
+                        PqcCryptoEngine.loadX25519PrivateKey(x25519PrivPath));
+            }
+            else {
+                LOG.info("Generating new X25519 key pair and saving to {} and {}", x25519PubPath, x25519PrivPath);
+                this.x25519KeyPair = PqcCryptoEngine.generateX25519KeyPair();
+                PqcCryptoEngine.saveKey(x25519PubPath, x25519KeyPair.getPublic().getEncoded());
+                PqcCryptoEngine.saveKey(x25519PrivPath, x25519KeyPair.getPrivate().getEncoded());
+            }
+        }
     }
 
     @Override
@@ -106,6 +125,11 @@ public class FileSystemKeyProvider implements KeyProvider {
                     "Unknown key ID '" + keyId + "'. FileSystemKeyProvider only supports key ID '" + DEFAULT_KEY_ID + "'");
         }
         return new KeyPair(publicKey, privateKey);
+    }
+
+    @Override
+    public KeyPair getX25519KeyPair() {
+        return x25519KeyPair;
     }
 
     @Override

--- a/src/main/java/io/kroxylicious/filter/pqc/crypto/KeyProvider.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/crypto/KeyProvider.java
@@ -86,6 +86,17 @@ public interface KeyProvider {
     List<String> listKeyIds();
 
     /**
+     * Return the X25519 static key pair for hybrid mode, if available.
+     * Providers that support hybrid mode persistence should override this
+     * method to return a persisted X25519 key pair.
+     *
+     * @return the X25519 key pair, or {@code null} if not available
+     */
+    default KeyPair getX25519KeyPair() {
+        return null;
+    }
+
+    /**
      * Release any resources held by this provider.
      * Called when the filter is shut down.
      */

--- a/src/main/java/io/kroxylicious/filter/pqc/crypto/PqcCryptoEngine.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/crypto/PqcCryptoEngine.java
@@ -104,6 +104,12 @@ public class PqcCryptoEngine {
 
     public PqcCryptoEngine(KemAlgorithm kemAlgorithm, boolean hybridMode,
                            PublicKey mlKemPublicKey, PrivateKey mlKemPrivateKey) {
+        this(kemAlgorithm, hybridMode, mlKemPublicKey, mlKemPrivateKey, null);
+    }
+
+    public PqcCryptoEngine(KemAlgorithm kemAlgorithm, boolean hybridMode,
+                           PublicKey mlKemPublicKey, PrivateKey mlKemPrivateKey,
+                           KeyPair x25519KeyPair) {
         this.kemAlgorithm = kemAlgorithm;
         this.hybridMode = hybridMode;
         this.mlKemPublicKey = mlKemPublicKey;
@@ -111,14 +117,19 @@ public class PqcCryptoEngine {
         this.secureRandom = new SecureRandom();
 
         if (hybridMode) {
-            try {
-                KeyPairGenerator x25519Gen = KeyPairGenerator.getInstance("X25519");
-                KeyPair staticKp = x25519Gen.generateKeyPair();
-                this.x25519StaticPublicKey = staticKp.getPublic();
-                this.x25519StaticPrivateKey = staticKp.getPrivate();
+            if (x25519KeyPair != null) {
+                this.x25519StaticPublicKey = x25519KeyPair.getPublic();
+                this.x25519StaticPrivateKey = x25519KeyPair.getPrivate();
             }
-            catch (GeneralSecurityException e) {
-                throw new IllegalStateException("Failed to generate X25519 static key pair for hybrid mode", e);
+            else {
+                try {
+                    KeyPair generated = generateX25519KeyPair();
+                    this.x25519StaticPublicKey = generated.getPublic();
+                    this.x25519StaticPrivateKey = generated.getPrivate();
+                }
+                catch (GeneralSecurityException e) {
+                    throw new IllegalStateException("Failed to generate X25519 static key pair for hybrid mode", e);
+                }
             }
         }
         else {
@@ -286,6 +297,32 @@ public class PqcCryptoEngine {
     public static void saveKey(Path path, byte[] encodedKey) throws IOException {
         Files.createDirectories(path.getParent());
         Files.write(path, encodedKey);
+    }
+
+    /**
+     * Generate a new X25519 key pair for hybrid mode.
+     */
+    public static KeyPair generateX25519KeyPair() throws GeneralSecurityException {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("X25519");
+        return kpg.generateKeyPair();
+    }
+
+    /**
+     * Load an X25519 public key from a file (X.509 DER encoded).
+     */
+    public static PublicKey loadX25519PublicKey(Path path) throws GeneralSecurityException, IOException {
+        byte[] keyBytes = Files.readAllBytes(path);
+        KeyFactory kf = KeyFactory.getInstance("X25519");
+        return kf.generatePublic(new X509EncodedKeySpec(keyBytes));
+    }
+
+    /**
+     * Load an X25519 private key from a file (PKCS#8 DER encoded).
+     */
+    public static PrivateKey loadX25519PrivateKey(Path path) throws GeneralSecurityException, IOException {
+        byte[] keyBytes = Files.readAllBytes(path);
+        KeyFactory kf = KeyFactory.getInstance("X25519");
+        return kf.generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
     }
 
     // --- Internal helpers ---

--- a/src/main/java/io/kroxylicious/filter/pqc/crypto/PqcKeyManager.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/crypto/PqcKeyManager.java
@@ -68,7 +68,8 @@ public class PqcKeyManager {
      */
     public PqcCryptoEngine createEngine(boolean hybridMode) throws GeneralSecurityException {
         KeyPair keyPair = keyProvider.getActiveKeyPair(algorithm);
-        return new PqcCryptoEngine(algorithm, hybridMode, keyPair.getPublic(), keyPair.getPrivate());
+        KeyPair x25519KeyPair = hybridMode ? keyProvider.getX25519KeyPair() : null;
+        return new PqcCryptoEngine(algorithm, hybridMode, keyPair.getPublic(), keyPair.getPrivate(), x25519KeyPair);
     }
 
     /**

--- a/src/test/java/io/kroxylicious/filter/pqc/crypto/FileSystemKeyProviderTest.java
+++ b/src/test/java/io/kroxylicious/filter/pqc/crypto/FileSystemKeyProviderTest.java
@@ -194,6 +194,108 @@ class FileSystemKeyProviderTest {
     }
 
     @Test
+    void shouldGenerateX25519KeysWhenHybridModeEnabled() throws Exception {
+        // Given
+        Path pubKeyPath = tempDir.resolve("pub.der");
+        Path privKeyPath = tempDir.resolve("priv.der");
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, true,
+                pubKeyPath.toString(), privKeyPath.toString(), null, null, null);
+
+        FileSystemKeyProvider provider = new FileSystemKeyProvider();
+
+        // When
+        provider.configure(config);
+
+        // Then
+        assertThat(tempDir.resolve("x25519-public.der")).exists();
+        assertThat(tempDir.resolve("x25519-private.der")).exists();
+        assertThat(provider.getX25519KeyPair()).isNotNull();
+        assertThat(provider.getX25519KeyPair().getPublic()).isNotNull();
+        assertThat(provider.getX25519KeyPair().getPrivate()).isNotNull();
+    }
+
+    @Test
+    void shouldLoadExistingX25519Keys() throws Exception {
+        // Given - generate and save keys first
+        Path pubKeyPath = tempDir.resolve("pub.der");
+        Path privKeyPath = tempDir.resolve("priv.der");
+        PqcEncryptionConfig config1 = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, true,
+                pubKeyPath.toString(), privKeyPath.toString(), null, null, null);
+
+        FileSystemKeyProvider provider1 = new FileSystemKeyProvider();
+        provider1.configure(config1);
+        KeyPair originalX25519 = provider1.getX25519KeyPair();
+
+        // When - load with a fresh provider
+        PqcEncryptionConfig config2 = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, true,
+                pubKeyPath.toString(), privKeyPath.toString(), null, null, null);
+        FileSystemKeyProvider provider2 = new FileSystemKeyProvider();
+        provider2.configure(config2);
+
+        // Then - same X25519 keys loaded
+        assertThat(provider2.getX25519KeyPair().getPublic().getEncoded())
+                .isEqualTo(originalX25519.getPublic().getEncoded());
+        assertThat(provider2.getX25519KeyPair().getPrivate().getEncoded())
+                .isEqualTo(originalX25519.getPrivate().getEncoded());
+    }
+
+    @Test
+    void shouldNotGenerateX25519KeysWhenHybridModeDisabled() throws Exception {
+        // Given
+        Path pubKeyPath = tempDir.resolve("pub.der");
+        Path privKeyPath = tempDir.resolve("priv.der");
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, false,
+                pubKeyPath.toString(), privKeyPath.toString(), null, null, null);
+
+        FileSystemKeyProvider provider = new FileSystemKeyProvider();
+
+        // When
+        provider.configure(config);
+
+        // Then
+        assertThat(tempDir.resolve("x25519-public.der")).doesNotExist();
+        assertThat(tempDir.resolve("x25519-private.der")).doesNotExist();
+        assertThat(provider.getX25519KeyPair()).isNull();
+    }
+
+    @Test
+    void shouldProduceWorkingHybridCryptoWithPersistedX25519Keys() throws Exception {
+        // Given - first provider generates keys
+        Path pubKeyPath = tempDir.resolve("pub.der");
+        Path privKeyPath = tempDir.resolve("priv.der");
+        PqcEncryptionConfig config = new PqcEncryptionConfig(
+                KemAlgorithm.ML_KEM_768, true,
+                pubKeyPath.toString(), privKeyPath.toString(), null, null, null);
+
+        FileSystemKeyProvider provider1 = new FileSystemKeyProvider();
+        provider1.configure(config);
+        KeyPair mlKem1 = provider1.getActiveKeyPair(KemAlgorithm.ML_KEM_768);
+        PqcCryptoEngine engine1 = new PqcCryptoEngine(
+                KemAlgorithm.ML_KEM_768, true, mlKem1.getPublic(), mlKem1.getPrivate(),
+                provider1.getX25519KeyPair());
+
+        byte[] plaintext = "cross-restart hybrid test".getBytes();
+        byte[] encrypted = engine1.encrypt(plaintext);
+
+        // When - second provider loads the same keys (simulates restart)
+        FileSystemKeyProvider provider2 = new FileSystemKeyProvider();
+        provider2.configure(config);
+        KeyPair mlKem2 = provider2.getActiveKeyPair(KemAlgorithm.ML_KEM_768);
+        PqcCryptoEngine engine2 = new PqcCryptoEngine(
+                KemAlgorithm.ML_KEM_768, true, mlKem2.getPublic(), mlKem2.getPrivate(),
+                provider2.getX25519KeyPair());
+
+        byte[] decrypted = engine2.decrypt(encrypted);
+
+        // Then
+        assertThat(decrypted).isEqualTo(plaintext);
+    }
+
+    @Test
     void shouldBeDiscoverableViaServiceLoader() {
         ServiceLoader<KeyProvider> loader = ServiceLoader.load(KeyProvider.class);
         Iterator<KeyProvider> it = loader.iterator();

--- a/src/test/java/io/kroxylicious/filter/pqc/crypto/PqcCryptoEngineTest.java
+++ b/src/test/java/io/kroxylicious/filter/pqc/crypto/PqcCryptoEngineTest.java
@@ -226,6 +226,28 @@ class PqcCryptoEngineTest {
     }
 
     @Test
+    void shouldDecryptWithProvidedX25519KeyPairAcrossEngineInstances() throws Exception {
+        // Given - encrypt with engine1 using a persisted X25519 key pair
+        KeyPair mlKemKeyPair = PqcCryptoEngine.generateKeyPair(KemAlgorithm.ML_KEM_768);
+        KeyPair x25519KeyPair = PqcCryptoEngine.generateX25519KeyPair();
+
+        PqcCryptoEngine engine1 = new PqcCryptoEngine(
+                KemAlgorithm.ML_KEM_768, true,
+                mlKemKeyPair.getPublic(), mlKemKeyPair.getPrivate(), x25519KeyPair);
+        byte[] plaintext = "cross-restart test".getBytes(StandardCharsets.UTF_8);
+        byte[] encrypted = engine1.encrypt(plaintext);
+
+        // When - decrypt with engine2 using the same X25519 key pair (simulates restart)
+        PqcCryptoEngine engine2 = new PqcCryptoEngine(
+                KemAlgorithm.ML_KEM_768, true,
+                mlKemKeyPair.getPublic(), mlKemKeyPair.getPrivate(), x25519KeyPair);
+        byte[] decrypted = engine2.decrypt(encrypted);
+
+        // Then
+        assertThat(decrypted).isEqualTo(plaintext);
+    }
+
+    @Test
     void hybridModeShouldProduceLargerEnvelopeThanPqcOnly() throws Exception {
         // Given
         KeyPair keyPair = PqcCryptoEngine.generateKeyPair(KemAlgorithm.ML_KEM_768);


### PR DESCRIPTION
## Summary

- Extended `KeyProvider` SPI with `getX25519KeyPair()` (default: null, backward-compatible)
- `PqcCryptoEngine` now accepts an optional X25519 key pair; falls back to ephemeral generation if not provided
- `FileSystemKeyProvider` auto-generates/loads `x25519-public.der` and `x25519-private.der` alongside ML-KEM keys when `hybridMode: true`
- `VaultKeyProvider` loads optional `x25519PublicKey` and `x25519PrivateKey` fields from the Vault secret
- `PqcKeyGeneratorCli` now generates X25519 keys alongside ML-KEM keys
- `vault-init.sh` updated to store X25519 keys in Vault
- 65 tests pass (48 core + 17 Vault), including cross-restart hybrid roundtrip tests

## Test plan

- [x] `shouldGenerateX25519KeysWhenHybridModeEnabled` — X25519 DER files created on disk
- [x] `shouldLoadExistingX25519Keys` — second provider loads same X25519 keys
- [x] `shouldNotGenerateX25519KeysWhenHybridModeDisabled` — no X25519 files when `hybridMode: false`
- [x] `shouldProduceWorkingHybridCryptoWithPersistedX25519Keys` — encrypt with provider1, decrypt with provider2 (simulates restart)
- [x] `shouldDecryptWithProvidedX25519KeyPairAcrossEngineInstances` — engine1 encrypts, engine2 decrypts with same X25519 key pair
- [x] All 65 existing tests pass (48 core + 17 Vault)

🤖 Generated with [Claude Code](https://claude.com/claude-code)