### PR TITLE
Fix #19: Narrow exception catches to GeneralSecurityException

### DIFF
--- a/src/main/java/io/kroxylicious/filter/pqc/PqcRecordEncryptionFilter.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/PqcRecordEncryptionFilter.java
@@ -101,7 +101,7 @@ public class PqcRecordEncryptionFilter implements
                 }
             }
         }
-        catch (Exception e) {
+        catch (GeneralSecurityException e) {
             if (failurePolicy == FailurePolicy.FAIL_CLOSED) {
                 LOG.error("Encryption failed (fail-closed): rejecting Produce request", e);
                 throw new RuntimeException("PQC encryption failed: " + e.getMessage(), e);
@@ -137,7 +137,7 @@ public class PqcRecordEncryptionFilter implements
                 }
             }
         }
-        catch (Exception e) {
+        catch (GeneralSecurityException e) {
             if (failurePolicy == FailurePolicy.FAIL_CLOSED) {
                 LOG.error("Decryption failed (fail-closed): rejecting Fetch response", e);
                 throw new RuntimeException("PQC decryption failed: " + e.getMessage(), e);


### PR DESCRIPTION
## Summary
- Replace `catch (Exception e)` with `catch (GeneralSecurityException e)` in both `onProduceRequest()` and `onFetchResponse()`
- Unexpected runtime exceptions (NPE, OOM, StackOverflow) now propagate naturally instead of being swallowed by the failure policy handler

## Test plan
- [x] All 75 tests pass (`mvn verify`)
- [x] Verified only `GeneralSecurityException` is caught — other exceptions propagate

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)