### PR TITLE
Fix #29: Include X25519 key in key ID computation for hybrid mode

### DIFF
--- a/src/main/java/io/kroxylicious/filter/pqc/crypto/PqcCryptoEngine.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/crypto/PqcCryptoEngine.java
@@ -137,7 +137,6 @@ public class PqcCryptoEngine {
         this.mlKemPublicKey = mlKemPublicKey;
         this.mlKemPrivateKey = mlKemPrivateKey;
         this.secureRandom = new SecureRandom();
-        this.keyId = computeKeyId(mlKemPublicKey);
 
         if (hybridMode) {
             if (x25519KeyPair != null) {
@@ -154,10 +153,12 @@ public class PqcCryptoEngine {
                     throw new IllegalStateException("Failed to generate X25519 static key pair for hybrid mode", e);
                 }
             }
+            this.keyId = computeKeyId(mlKemPublicKey, x25519StaticPublicKey);
         }
         else {
             this.x25519StaticPublicKey = null;
             this.x25519StaticPrivateKey = null;
+            this.keyId = computeKeyId(mlKemPublicKey);
         }
     }
 
@@ -338,14 +339,16 @@ public class PqcCryptoEngine {
     }
 
     /**
-     * Return the key ID for this engine, derived from the ML-KEM public key.
+     * Return the key ID for this engine, derived from the key material used for encryption.
+     * In PQC-only mode this is derived from the ML-KEM public key alone.
+     * In hybrid mode this incorporates both the ML-KEM and X25519 public keys.
      */
     public int getKeyId() {
         return keyId;
     }
 
     /**
-     * Compute a 4-byte key ID from an ML-KEM public key.
+     * Compute a 4-byte key ID from an ML-KEM public key (PQC-only mode).
      * The key ID is the first 4 bytes of SHA-256(publicKey.getEncoded()),
      * interpreted as a big-endian int.
      */
@@ -353,6 +356,23 @@ public class PqcCryptoEngine {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] hash = digest.digest(publicKey.getEncoded());
+            return ByteBuffer.wrap(hash, 0, KEY_ID_LENGTH).getInt();
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    /**
+     * Compute a 4-byte key ID from both ML-KEM and X25519 public keys (hybrid mode).
+     * The key ID is the first 4 bytes of SHA-256(mlKemPublicKey.getEncoded() || x25519PublicKey.getEncoded()),
+     * interpreted as a big-endian int. This ensures the key ID changes if either key changes.
+     */
+    public static int computeKeyId(PublicKey mlKemPublicKey, PublicKey x25519PublicKey) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(mlKemPublicKey.getEncoded());
+            byte[] hash = digest.digest(x25519PublicKey.getEncoded());
             return ByteBuffer.wrap(hash, 0, KEY_ID_LENGTH).getInt();
         }
         catch (NoSuchAlgorithmException e) {

--- a/src/main/java/io/kroxylicious/filter/pqc/crypto/PqcKeyManager.java
+++ b/src/main/java/io/kroxylicious/filter/pqc/crypto/PqcKeyManager.java
@@ -91,7 +91,9 @@ public class PqcKeyManager {
         for (String keyId : keyProvider.listKeyIds()) {
             try {
                 KeyPair kp = keyProvider.getKeyPairById(keyId, algorithm);
-                int computedId = PqcCryptoEngine.computeKeyId(kp.getPublic());
+                int computedId = (hybridMode && x25519KeyPair != null)
+                        ? PqcCryptoEngine.computeKeyId(kp.getPublic(), x25519KeyPair.getPublic())
+                        : PqcCryptoEngine.computeKeyId(kp.getPublic());
                 if (!engineCache.containsKey(computedId)) {
                     PqcCryptoEngine retiredEngine = new PqcCryptoEngine(algorithm, hybridMode,
                             kp.getPublic(), kp.getPrivate(), x25519KeyPair);

--- a/src/test/java/io/kroxylicious/filter/pqc/crypto/PqcCryptoEngineTest.java
+++ b/src/test/java/io/kroxylicious/filter/pqc/crypto/PqcCryptoEngineTest.java
@@ -372,4 +372,74 @@ class PqcCryptoEngineTest {
         // Then
         assertThat(engine.getKeyId()).isEqualTo(PqcCryptoEngine.computeKeyId(keyPair.getPublic()));
     }
+
+    @Test
+    void hybridKeyIdShouldIncludeBothKeys() throws Exception {
+        // Given
+        KeyPair mlKemKeyPair = PqcCryptoEngine.generateKeyPair(KemAlgorithm.ML_KEM_768);
+        KeyPair x25519KeyPair = PqcCryptoEngine.generateX25519KeyPair();
+
+        // When
+        PqcCryptoEngine engine = new PqcCryptoEngine(
+                KemAlgorithm.ML_KEM_768, true,
+                mlKemKeyPair.getPublic(), mlKemKeyPair.getPrivate(), x25519KeyPair);
+
+        // Then - hybrid key ID should use both keys, not just ML-KEM
+        int pqcOnlyKeyId = PqcCryptoEngine.computeKeyId(mlKemKeyPair.getPublic());
+        int hybridKeyId = PqcCryptoEngine.computeKeyId(mlKemKeyPair.getPublic(), x25519KeyPair.getPublic());
+        assertThat(engine.getKeyId()).isEqualTo(hybridKeyId);
+        assertThat(engine.getKeyId()).isNotEqualTo(pqcOnlyKeyId);
+    }
+
+    @Test
+    void hybridKeyIdShouldChangeWhenX25519KeyChanges() throws Exception {
+        // Given - same ML-KEM key, different X25519 keys
+        KeyPair mlKemKeyPair = PqcCryptoEngine.generateKeyPair(KemAlgorithm.ML_KEM_768);
+        KeyPair x25519KeyPair1 = PqcCryptoEngine.generateX25519KeyPair();
+        KeyPair x25519KeyPair2 = PqcCryptoEngine.generateX25519KeyPair();
+
+        // When
+        PqcCryptoEngine engine1 = new PqcCryptoEngine(
+                KemAlgorithm.ML_KEM_768, true,
+                mlKemKeyPair.getPublic(), mlKemKeyPair.getPrivate(), x25519KeyPair1);
+        PqcCryptoEngine engine2 = new PqcCryptoEngine(
+                KemAlgorithm.ML_KEM_768, true,
+                mlKemKeyPair.getPublic(), mlKemKeyPair.getPrivate(), x25519KeyPair2);
+
+        // Then - key IDs should differ because X25519 keys differ
+        assertThat(engine1.getKeyId()).isNotEqualTo(engine2.getKeyId());
+    }
+
+    @Test
+    void hybridKeyIdShouldBeDeterministic() throws Exception {
+        // Given
+        KeyPair mlKemKeyPair = PqcCryptoEngine.generateKeyPair(KemAlgorithm.ML_KEM_768);
+        KeyPair x25519KeyPair = PqcCryptoEngine.generateX25519KeyPair();
+
+        // When
+        int keyId1 = PqcCryptoEngine.computeKeyId(mlKemKeyPair.getPublic(), x25519KeyPair.getPublic());
+        int keyId2 = PqcCryptoEngine.computeKeyId(mlKemKeyPair.getPublic(), x25519KeyPair.getPublic());
+
+        // Then
+        assertThat(keyId1).isEqualTo(keyId2);
+    }
+
+    @Test
+    void hybridEnvelopeShouldContainHybridKeyId() throws Exception {
+        // Given
+        KeyPair mlKemKeyPair = PqcCryptoEngine.generateKeyPair(KemAlgorithm.ML_KEM_768);
+        KeyPair x25519KeyPair = PqcCryptoEngine.generateX25519KeyPair();
+        PqcCryptoEngine engine = new PqcCryptoEngine(
+                KemAlgorithm.ML_KEM_768, true,
+                mlKemKeyPair.getPublic(), mlKemKeyPair.getPrivate(), x25519KeyPair);
+        byte[] plaintext = "hybrid key id envelope test".getBytes(StandardCharsets.UTF_8);
+
+        // When
+        byte[] encrypted = engine.encrypt(plaintext);
+
+        // Then - embedded key ID should match the hybrid-computed key ID
+        int embeddedKeyId = ByteBuffer.wrap(encrypted, 1, 4).getInt();
+        int expectedKeyId = PqcCryptoEngine.computeKeyId(mlKemKeyPair.getPublic(), x25519KeyPair.getPublic());
+        assertThat(embeddedKeyId).isEqualTo(expectedKeyId);
+    }
 }


### PR DESCRIPTION
## Summary
- In hybrid mode, the key ID is now computed as `SHA-256(mlKemPublicKey.getEncoded() || x25519PublicKey.getEncoded())` instead of only using the ML-KEM public key
- This ensures that if the X25519 key pair changes (e.g., lost during restart), the key ID also changes, triggering proper "unknown key" handling instead of silent AES-GCM tag failure
- Updated `PqcKeyManager.preloadRetiredKeys` to use hybrid key ID computation when in hybrid mode

## Test plan
- [x] `hybridKeyIdShouldIncludeBothKeys` — verifies hybrid key ID differs from PQC-only key ID
- [x] `hybridKeyIdShouldChangeWhenX25519KeyChanges` — verifies key ID changes when X25519 key changes (same ML-KEM key)
- [x] `hybridKeyIdShouldBeDeterministic` — verifies same inputs produce same key ID
- [x] `hybridEnvelopeShouldContainHybridKeyId` — verifies the envelope embeds the hybrid-computed key ID
- [x] All 79 existing + new tests pass

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)